### PR TITLE
Fixed an issue during inital os2forms repo setup by adding drupal:key_auth as a dependency for OS2Form REST API.

### DIFF
--- a/web/modules/custom/os2forms_rest_api/os2forms_rest_api.info.yml
+++ b/web/modules/custom/os2forms_rest_api/os2forms_rest_api.info.yml
@@ -3,3 +3,5 @@ type: module
 description: 'OS2Form REST API'
 package: Web services
 core_version_requirement: ^9
+dependencies:		
+		- drupal:key_auth


### PR DESCRIPTION
Fixed an issue during inital os2forms repo setup by adding drupal:key_auth as a dependency for OS2Form REST API.