### PR TITLE
DW-557: Updated drupal/maestro

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4128,17 +4128,17 @@
         },
         {
             "name": "drupal/maestro",
-            "version": "3.0.1-rc3",
+            "version": "3.0.1-rc4",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/maestro.git",
-                "reference": "3.0.1-rc3"
+                "reference": "3.0.1-rc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/maestro-3.0.1-rc3.zip",
-                "reference": "3.0.1-rc3",
-                "shasum": "9b2344cfd2ea0d0175f1fa35c970c44881877305"
+                "url": "https://ftp.drupal.org/files/projects/maestro-3.0.1-rc4.zip",
+                "reference": "3.0.1-rc4",
+                "shasum": "79068c7b47cbce5a473031940ad551e6df7530c6"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9"
@@ -4150,8 +4150,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.1-rc3",
-                    "datestamp": "1623431606",
+                    "version": "3.0.1-rc4",
+                    "datestamp": "1657119073",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."


### PR DESCRIPTION
Upgrades to https://www.drupal.org/project/maestro/releases/3.0.1-rc4