### PR TITLE
SUPP0RT-532: Updated default format of webform submission date in email handler body text

### DIFF
--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -193,8 +193,8 @@ mail:
   default_sender_mail: ''
   default_sender_name: ''
   default_subject: '[webform_submission:source-title] (fra [site:name])'
-  default_body_text: "Submitted on [webform_submission:created]\r\nSubmitted by: [webform_submission:user]\r\n\r\nSubmitted values are:\r\n[webform_submission:values]\r\n"
-  default_body_html: "<p>Submitted on [webform_submission:created]</p>\r\n<p>Submitted by: [webform_submission:user]</p>\r\n<p>Submitted values are:</p>\r\n[webform_submission:values]\r\n"
+  default_body_text: "Submitted on [webform_submission:created:custom:d. F Y]\r\nSubmitted by: [webform_submission:user]\r\n\r\nSubmitted values are:\r\n[webform_submission:values]\r\n"
+  default_body_html: "<p>Submitted on [webform_submission:created:custom:d. F Y]</p>\r\n<p>Submitted by: [webform_submission:user]</p>\r\n<p>Submitted values are:</p>\r\n[webform_submission:values]\r\n"
   roles: {  }
 export:
   temp_directory: ''


### PR DESCRIPTION
When new email handlers in webforms are created, the default format of the [webform_submission:created] will be of the format "d. F. Y", instead of the default format "D, m/d/Y - H:i"