### PR TITLE
DW: Update itk-dev/os2forms_cvr_lookup version to 1.2.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7963,16 +7963,16 @@
         },
         {
             "name": "itk-dev/os2forms_cvr_lookup",
-            "version": "1.1.1",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itk-dev/os2forms_cvr_lookup.git",
-                "reference": "2a1d027a8fe4225d2f0c301b58e40cee4b7d3601"
+                "reference": "b51a588c2a45d57ee69c0450ce627a2c0eb4364e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/itk-dev/os2forms_cvr_lookup/zipball/2a1d027a8fe4225d2f0c301b58e40cee4b7d3601",
-                "reference": "2a1d027a8fe4225d2f0c301b58e40cee4b7d3601",
+                "url": "https://api.github.com/repos/itk-dev/os2forms_cvr_lookup/zipball/b51a588c2a45d57ee69c0450ce627a2c0eb4364e",
+                "reference": "b51a588c2a45d57ee69c0450ce627a2c0eb4364e",
                 "shasum": ""
             },
             "require": {
@@ -8006,10 +8006,10 @@
             ],
             "description": "Provides integration to CVR service provided by Serviceplatformen.",
             "support": {
-                "source": "https://github.com/itk-dev/os2forms_cvr_lookup/tree/1.1.1",
+                "source": "https://github.com/itk-dev/os2forms_cvr_lookup/tree/1.2.0",
                 "issues": "https://github.com/itk-dev/os2forms_cvr_lookup/issues"
             },
-            "time": "2021-08-05T10:08:17+00:00"
+            "time": "2022-07-01T12:08:13+00:00"
         },
         {
             "name": "itk-dev/os2forms_digital_post",


### PR DESCRIPTION
Bumps version of itk-dev/os2forms_cvr_lookup to 1.2.0.

https://github.com/itk-dev/os2forms_cvr_lookup/releases/tag/1.2.0

This allows prepopulation of CVR element.

