### PR TITLE
DW-579: Disabled description in popups

### DIFF
--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -318,7 +318,7 @@ ui:
   promotions_disabled: false
   support_disabled: false
   details_save: true
-  description_help: true
+  description_help: false
   toolbar_item: false
 libraries:
   excluded_libraries:


### PR DESCRIPTION
https://jira.itkdev.dk/browse/DW-579

Makes field descriptions easier to use (and see) by not hiding them in a hover popup.

Before:

![selvbetjening aarhuskommune dk_da_admin_structure_webform_manage_1_flow_test_24_8_2022_handlers_config_entity=1_flow_test_24_8_2022 (1)](https://user-images.githubusercontent.com/11267554/190577569-01dd3e6d-b244-4b13-b7f4-9c4ef16ec915.png)

After:

![selvbetjening aarhuskommune dk_da_admin_structure_webform_manage_1_flow_test_24_8_2022_handlers_config_entity=1_flow_test_24_8_2022](https://user-images.githubusercontent.com/11267554/190577626-1a9f3a45-df27-431a-8467-cefa9dcea32c.png)
