### PR TITLE
FORMS-651: Update itk-dev/os2forms_cpr_lookup

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8110,16 +8110,16 @@
         },
         {
             "name": "itk-dev/os2forms_cpr_lookup",
-            "version": "1.6.7",
+            "version": "1.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itk-dev/os2forms_cpr_lookup.git",
-                "reference": "b3abb5742917065677f659494e93e916a12e2ab6"
+                "reference": "783b0bfc82c8c2b1c562cb4e7193bb034b637012"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/itk-dev/os2forms_cpr_lookup/zipball/b3abb5742917065677f659494e93e916a12e2ab6",
-                "reference": "b3abb5742917065677f659494e93e916a12e2ab6",
+                "url": "https://api.github.com/repos/itk-dev/os2forms_cpr_lookup/zipball/783b0bfc82c8c2b1c562cb4e7193bb034b637012",
+                "reference": "783b0bfc82c8c2b1c562cb4e7193bb034b637012",
                 "shasum": ""
             },
             "require": {
@@ -8162,10 +8162,10 @@
             ],
             "description": "Provides integration to CPR service provided by Serviceplatformen.",
             "support": {
-                "source": "https://github.com/itk-dev/os2forms_cpr_lookup/tree/1.6.7",
+                "source": "https://github.com/itk-dev/os2forms_cpr_lookup/tree/1.6.8",
                 "issues": "https://github.com/itk-dev/os2forms_cpr_lookup/issues"
             },
-            "time": "2022-09-23T09:00:41+00:00"
+            "time": "2022-11-28T12:57:17+00:00"
         },
         {
             "name": "itk-dev/os2forms_cvr_lookup",


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORMS-651

Updates `itk-dev/os2forms_cpr_lookup` to version [1.6.8](https://github.com/itk-dev/os2forms_cpr_lookup/releases/tag/1.6.8).
