### PR TITLE
FORMS-660: Added patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 * Installerede [Os2forms Failed jobs
   1.0.0](https://github.com/itk-dev/os2forms_failed_jobs/releases/tag/1.0.0).
 * Tilføjede danske oversættelser.
+* Tilføjede patch
+  <https://www.drupal.org/files/issues/2022-03-15/content_entity_revisions-3260602-07.patch>.
 
 ### Fix
 

--- a/composer.json
+++ b/composer.json
@@ -127,7 +127,8 @@
                 "Revoking group access does not reflect on applied roles (https://www.drupal.org/project/openid_connect/issues/3224128)": "https://git.drupalcode.org/project/openid_connect/-/merge_requests/31.diff"
             },
             "drupal/config_entity_revisions":  {
-                "Add check to see if entity revision actually exists(https://www.drupal.org/project/config_entity_revisions/issues/3277467)": "https://www.drupal.org/files/issues/2022-04-27/add-check-to-see-if-entity-revision-actually-exists-3277467-3.patch"
+                "Add check to see if entity revision actually exists(https://www.drupal.org/project/config_entity_revisions/issues/3277467)": "https://www.drupal.org/files/issues/2022-04-27/add-check-to-see-if-entity-revision-actually-exists-3277467-3.patch",
+                "https://www.drupal.org/project/config_entity_revisions/issues/3260602": "https://www.drupal.org/files/issues/2022-03-15/content_entity_revisions-3260602-07.patch"
             },
             "drupal/webform_rest": {
                 "Added ability to modify response data sent from Webform Submission endpoint": "web/modules/custom/os2forms_rest_api/patches/webform_rest_submission.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be26523c2904567f0d5b1af9683fbaf6",
+    "content-hash": "63b65e92e3cd32d5ace74b67a95a54eb",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORMS-660

Adds a patch on an outdated module: https://www.drupal.org/project/config_entity_revisions/issues/3260602 to resolve the issue shown below. The real solution is to update the module.

```
Notice: Trying to access array offset on value of type null in Drupal\config_entity_revisions\ConfigEntityRevisionsControllerBase->createUpdateRevision() (line 228 of modules/contrib/config_entity_revisions/src/ConfigEntityRevisionsControllerBase.php).
Drupal\config_entity_revisions\ConfigEntityRevisionsControllerBase->createUpdateRevision(Object) (Line: 123)
webform_revisions_webform_update(Object)
call_user_func_array(Object, Array) (Line: 426)
…
```