### PR TITLE
Configure digital post queues to be processed via deamon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## Under udvikling
 
+* Behandl digital post-køer via rigtig [`cron`](https://en.wikipedia.org/wiki/Cron).
+
 ## [1.7.0] 13.02.2023
 
 ### Tilføjet

--- a/config/sync/advancedqueue.advancedqueue_queue.os2forms_digital_post.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.os2forms_digital_post.yml
@@ -12,6 +12,10 @@ label: 'OSForms digital post'
 backend: database
 backend_configuration:
   lease_time: 300
-processor: cron
-processing_time: 90
+processor: daemon
+processing_time: 280
 locked: false
+threshold:
+  type: 0
+  limit: 0
+  state: all

--- a/config/sync/advancedqueue.advancedqueue_queue.send_digital_post.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.send_digital_post.yml
@@ -7,6 +7,10 @@ label: 'Send Digital Post'
 backend: database
 backend_configuration:
   lease_time: 300
-processor: cron
-processing_time: 90
+processor: daemon
+processing_time: 280
 locked: false
+threshold:
+  type: 0
+  limit: 0
+  state: all


### PR DESCRIPTION
Processing digital post queues via Drupal's cron run seems to not be able to handle many posts. Therefore we use “real” cron to process the queues.
