### PR TITLE
FORMS-742: Update config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 * itk-dev/getorganized-api-client-php (1.2.0)
 * Udvidet GetOrganized handler med funktionalitet
   til at arkivere vedhæftede filer som bilag i GO.
+* Konfiguration ændringer
+  * Aktiverede `Signature` og `Email confirm` webform elementer.
+  * Brug af `daemon` til GetOrganized og REST API queues.
+  * Sortede maestro flows efter `id` på `/maestro-all-flows`.
 
 ## [1.7.1] 24.02.2023
 

--- a/config/sync/advancedqueue.advancedqueue_queue.get_organized_queue.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.get_organized_queue.yml
@@ -1,9 +1,7 @@
-uuid: 4ed57737-bba6-407f-9ee8-8ec4a16a9188
+uuid: 51742614-4854-4e73-b6c3-7446cd47e470
 langcode: da
 status: true
 dependencies: {  }
-_core:
-  default_config_hash: Hx9J_hTsoH1EoFJiAhy9EwMfk1Txmsp5M71RrUZnodo
 id: get_organized_queue
 label: 'Get Organized Queue'
 backend: database

--- a/config/sync/advancedqueue.advancedqueue_queue.get_organized_queue.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.get_organized_queue.yml
@@ -1,12 +1,18 @@
-uuid: 51742614-4854-4e73-b6c3-7446cd47e470
+uuid: 4ed57737-bba6-407f-9ee8-8ec4a16a9188
 langcode: da
 status: true
 dependencies: {  }
+_core:
+  default_config_hash: Hx9J_hTsoH1EoFJiAhy9EwMfk1Txmsp5M71RrUZnodo
 id: get_organized_queue
 label: 'Get Organized Queue'
 backend: database
 backend_configuration:
   lease_time: 300
-processor: cron
-processing_time: 90
+processor: daemon
+processing_time: 280
 locked: false
+threshold:
+  type: 0
+  limit: 0
+  state: all

--- a/config/sync/advancedqueue.advancedqueue_queue.os2forms_api_request_handler.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.os2forms_api_request_handler.yml
@@ -7,6 +7,10 @@ label: os2forms_api_request_handler
 backend: database
 backend_configuration:
   lease_time: 300
-processor: cron
-processing_time: 90
+processor: daemon
+processing_time: 280
 locked: false
+threshold:
+  type: 0
+  limit: 0
+  state: all

--- a/config/sync/views.view.maestro_all_flows.yml
+++ b/config/sync/views.view.maestro_all_flows.yml
@@ -541,7 +541,22 @@ display:
         type: tag
         options: {  }
       empty: {  }
-      sorts: {  }
+      sorts:
+        process_id:
+          id: process_id
+          table: maestro_process
+          field: process_id
+          relationship: none
+          group_type: group
+          admin_label: Sorteringskriterier
+          entity_type: maestro_process
+          entity_field: process_id
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: 'Proces id'
+            field_identifier: process_id
+          exposed: false
       arguments: {  }
       filters:
         process_name:
@@ -653,7 +668,7 @@ display:
       footer: {  }
       display_extenders: {  }
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -671,7 +686,7 @@ display:
       display_extenders: {  }
       path: maestro-all-flows
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'

--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -177,7 +177,6 @@ element:
     webform_attachment_url: webform_attachment_url
     webform_codemirror: webform_codemirror
     webform_computed_token: webform_computed_token
-    webform_email_confirm: webform_email_confirm
     webform_email_multiple: webform_email_multiple
     webform_entity_checkboxes: webform_entity_checkboxes
     webform_entity_radios: webform_entity_radios
@@ -188,7 +187,6 @@ element:
     webform_message: webform_message
     webform_name: webform_name
     webform_same: webform_same
-    webform_signature: webform_signature
     webform_tableselect_sort: webform_tableselect_sort
     webform_telephone: webform_telephone
 html_editor:


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORMS-742

* Enables `Signature` and `Email confirm` elements
* Sorts maestro tasks by id on `/maestro-all-flows`
* Updates GetOrganized and REST API advanced queues to use daemon

The changes to queues mean we have to add our own cronjobs for running the queues. These have been added but commented out for now until needed.