### PR TITLE
FORMS-763: Ignore attachment component settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,4 +221,5 @@ config/sync/**/webform.webform.*
 
 # Ignore nemlogin settings
 config/sync/os2web_nemlogin.settings.yml
-
+# Ignore attachment components
+config/sync/os2forms_attachment.os2forms_attachment_component.*.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 ## [Under udvikling]
 
 * Fiksede GitHub Action til at installere site.
+* Opdaterede “config ignore”-regler
 
 ## [2.0.0] 29.03.2023
 

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -6,3 +6,6 @@ ignored_config_entities:
   - system.site
   - 'webform.webform.*'
   - os2web_nemlogin.settings
+  - '# Ignore global header, colophon and footer settings'
+  - 'webform.settings:third_party_settings.webform_entity_print.template'
+  - 'os2forms_attachment.os2forms_attachment_component.*'


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORMS-763

Ignores attachment component settings.

*Note*: 

```yaml
# Ignore global header, colophon and footer settings
webform.settings:third_party_settings.webform_entity_print.template
os2forms_attachment.os2forms_attachment_component.*
```

should be added on `/admin/config/development/configuration/ignore` before deploying this.
