### PR TITLE
SUPP0RT-963: Bumped os2forms_get_organized version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* os2forms/os2forms_get_organized (1.1.0)
 * Installerede `os2forms/os2forms_get_organized`
   (<https://github.com/itk-dev/os2forms_selvbetjening/pull/174>).
 * Opdaterede CVR-elementer og konfiguration af CVR-opslagservice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 ## [Under udvikling]
 
 * os2forms/os2forms_get_organized (1.1.0)
+  (<https://github.com/itk-dev/os2forms_selvbetjening/pull/177>).
 * Installerede `os2forms/os2forms_get_organized`
   (<https://github.com/itk-dev/os2forms_selvbetjening/pull/174>).
 * Opdaterede CVR-elementer og konfiguration af CVR-opslagservice

--- a/README.md
+++ b/README.md
@@ -78,20 +78,6 @@ $settings['locale_custom_strings_da'][''] = [
 ];
 ```
 
-### GetOrganized
-
-To use the custom GetOrganized module the module must be
-configured in the `settings.local.php` file:
-
-```php
-# settings.local.php
-$config['os2forms_get_organized'] = [
-  'username' => '…',
-  'password' => '…',
-  'base_url' => '…',
-];
-```
-
 ### Selvbetjening Module
 
 The `OS2Forms Selvbetjening` module updates the following:

--- a/composer.lock
+++ b/composer.lock
@@ -9894,16 +9894,16 @@
         },
         {
             "name": "os2forms/os2forms_get_organized",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OS2Forms/os2forms_get_organized.git",
-                "reference": "78e167dc05e141892f33d59db758648fa6f31245"
+                "reference": "7e8a8bf96d8a0c8c1ff924041840de27c09f94d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OS2Forms/os2forms_get_organized/zipball/78e167dc05e141892f33d59db758648fa6f31245",
-                "reference": "78e167dc05e141892f33d59db758648fa6f31245",
+                "url": "https://api.github.com/repos/OS2Forms/os2forms_get_organized/zipball/7e8a8bf96d8a0c8c1ff924041840de27c09f94d3",
+                "reference": "7e8a8bf96d8a0c8c1ff924041840de27c09f94d3",
                 "shasum": ""
             },
             "require": {
@@ -9931,9 +9931,9 @@
             "description": "OS2Forms GetOrganized integration",
             "support": {
                 "issues": "https://github.com/OS2Forms/os2forms_get_organized/issues",
-                "source": "https://github.com/OS2Forms/os2forms_get_organized/tree/1.0.0"
+                "source": "https://github.com/OS2Forms/os2forms_get_organized/tree/1.1.0"
             },
-            "time": "2023-03-29T06:35:45+00:00"
+            "time": "2023-04-25T11:38:39+00:00"
         },
         {
             "name": "os2forms/os2forms_organisation",


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-963

* Updated `os2forms/os2forms_get_organized` to version 1.1.0