### PR TITLE
SUPP0RT-1066: Update to os2forms GetOrganized to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Opdaterede til [OS2Forms GetOrganized
+  1.1.2](https://github.com/OS2Forms/os2forms_get_organized/releases/tag/1.1.2)
+
 ## [2.3.0]
 
 * Opdaterede til [OS2Web Data lookup

--- a/composer.lock
+++ b/composer.lock
@@ -9831,16 +9831,16 @@
         },
         {
             "name": "os2forms/os2forms_get_organized",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OS2Forms/os2forms_get_organized.git",
-                "reference": "d4c993a0e96339fa0afe1331cfe82d04f947325f"
+                "reference": "5b74eace56e08cd7d51bbee43590f1b36ad41d7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OS2Forms/os2forms_get_organized/zipball/d4c993a0e96339fa0afe1331cfe82d04f947325f",
-                "reference": "d4c993a0e96339fa0afe1331cfe82d04f947325f",
+                "url": "https://api.github.com/repos/OS2Forms/os2forms_get_organized/zipball/5b74eace56e08cd7d51bbee43590f1b36ad41d7f",
+                "reference": "5b74eace56e08cd7d51bbee43590f1b36ad41d7f",
                 "shasum": ""
             },
             "require": {
@@ -9868,9 +9868,9 @@
             "description": "OS2Forms GetOrganized integration",
             "support": {
                 "issues": "https://github.com/OS2Forms/os2forms_get_organized/issues",
-                "source": "https://github.com/OS2Forms/os2forms_get_organized/tree/1.1.1"
+                "source": "https://github.com/OS2Forms/os2forms_get_organized/tree/1.1.2"
             },
-            "time": "2023-05-03T13:19:30+00:00"
+            "time": "2023-06-22T07:37:40+00:00"
         },
         {
             "name": "os2forms/os2forms_organisation",


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-1066

* Updates `os2forms/os2forms_get_organized` from `1.1.1` to `1.1.2`