### PR TITLE
FORDRIF-298: Config ignored drupal leaflet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## In develop
 
+* Tilføjede drupal leaflet til config ignore.
 * Opdaterede til [Os2forms GetOrganized
   1.1.4](https://github.com/OS2Forms/os2forms_get_organized/releases/tag/1.1.4)
 * Nedgraderede til `drupal/leaflet` `10.0.12`

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -22,3 +22,6 @@ ignored_config_entities:
   - 'os2web_datalookup.serviceplatformen_cpr_extended:certfile_passphrase'
   - 'os2web_datalookup.serviceplatformen_cpr_extended:certfile'
   - 'os2web_datalookup.serviceplatformen_cpr_extended:certfile_test'
+  - '# Ignore leaflet layers'
+  - 'leaflet_layers.map_bundle.*'
+  - 'leaflet_layers.map_layer.*'


### PR DESCRIPTION
https://jira.itkdev.dk/browse/FORDRIF-298

* Adds leaflet layers to config ignore

User permission to `site admin` will be handled in a separate PR.