### PR TITLE
FORDRIF-298: Added custom permission alteration module giving site ad…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@
 !/web/modules/custom/os2forms_selvbetjening
 !/web/modules/custom/os2forms_user_menu
 !/web/modules/custom/os2forms_fbs_handler
+!/web/modules/custom/os2forms_permission_alterations
 
 # Ignore site specific modules.
 /web/sites/*/modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## In develop
 
+* Tilføjede custom modulet `os2forms_permission_alterations`.
+* Tilføjede `administer leaflet layers` permission til site admin rollen.
 * Opdaterede dependencies
 * Opdaterede til [OS2Forms NemLogin OpenID Connect
   2.0.0](https://github.com/itk-dev/os2forms_nemlogin_openid_connect/releases/tag/2.0.0)

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -85,6 +85,7 @@ module:
   os2forms_nemlogin_openid_connect: 0
   os2forms_organisation: 0
   os2forms_organisation_openid_connect: 0
+  os2forms_permission_alterations: 0
   os2forms_permissions_by_term: 0
   os2forms_rest_api: 0
   os2forms_sbsys: 0

--- a/config/sync/user.role.site_admin.yml
+++ b/config/sync/user.role.site_admin.yml
@@ -18,6 +18,7 @@ dependencies:
     - locale
     - node
     - os2forms_failed_jobs
+    - os2forms_permission_alterations
     - search
     - system
     - taxonomy
@@ -51,6 +52,7 @@ permissions:
   - 'administer block_content form display'
   - 'administer content types'
   - 'administer display modes'
+  - 'administer leaflet layers'
   - 'administer node display'
   - 'administer node form display'
   - 'administer taxonomy_term display'

--- a/web/modules/custom/os2forms_permission_alterations/README.md
+++ b/web/modules/custom/os2forms_permission_alterations/README.md
@@ -1,0 +1,14 @@
+# OS2Forms Permission Alterations
+
+Module for altering permissions on entities and routes.
+
+## Alterations
+
+Module contains the following alterations
+
+### Leaflet layers
+
+* Added `administer leaflet layers` permission
+* Changed `admin_permission` from `administer site configuration` to
+`administer leaflet layers` on the `Drupal\leaflet_layers\Entity\MapLayer`
+and `Drupal\leaflet_layers\Entity\MapBundle` entities.

--- a/web/modules/custom/os2forms_permission_alterations/os2forms_permission_alterations.info.yml
+++ b/web/modules/custom/os2forms_permission_alterations/os2forms_permission_alterations.info.yml
@@ -1,0 +1,7 @@
+name: 'OS2Forms permission alterations'
+type: module
+description: 'Custom module for altering permissions on entities or routes'
+package: 'OS2Forms'
+core_version_requirement: ^9
+dependencies:
+  - 'leaflet_layers:leaflet_layers'

--- a/web/modules/custom/os2forms_permission_alterations/os2forms_permission_alterations.module
+++ b/web/modules/custom/os2forms_permission_alterations/os2forms_permission_alterations.module
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Module file for the os2forms_permission_alterations module.
+ */
+
+/**
+ * Implements hook_entity_type_alter().
+ */
+function os2forms_permission_alterations_entity_type_alter(array &$entity_types) {
+
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
+
+  if (isset($entity_types['map_layer'])) {
+    $entity_types['map_layer']->set('admin_permission', 'administer leaflet layers');
+  }
+
+  if (isset($entity_types['map_bundle'])) {
+    $entity_types['map_bundle']->set('admin_permission', 'administer leaflet layers');
+  }
+}

--- a/web/modules/custom/os2forms_permission_alterations/os2forms_permission_alterations.permissions.yml
+++ b/web/modules/custom/os2forms_permission_alterations/os2forms_permission_alterations.permissions.yml
@@ -1,0 +1,3 @@
+administer leaflet layers:
+  title: 'Administer leaflet layers'
+  description: 'Administer leaflet map bundles and layers.'


### PR DESCRIPTION
…min leaflet_layers configuration permission

https://jira.itkdev.dk/browse/FORDRIF-298

* Adds custom module `os2forms_permission_alterations`
  *  Adds `administer leaflet layers` permission
  * Alters `drupal/leaflet_layers` entities (`MapLayer` & `MapBundle`) admin permission to `administer leaflet layers`
* Grants the `administer leaflet layers` permission to the `site_admin` role.