### PR TITLE
Hotfix/Sunday businesshours convert 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 * Opdaterede til [OS2Forms organisation
   1.3.3](https://github.com/itk-dev/os2forms_organisation/releases/tag/1.3.3)
 * Tilføjede beskrivelsestekst til email-handler.
+* Converted internal notation of business hours
+  for sunday from (7) to (0) [#128](https://github.com/itk-dev/drupal_webform_booking_module/pull/128)
 
 ## [2.6.2] 2023-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
   1.3.3](https://github.com/itk-dev/os2forms_organisation/releases/tag/1.3.3)
 * Tilføjede beskrivelsestekst til email-handler.
 * Converted internal notation of business hours
-  for sunday from (7) to (0) [#128](https://github.com/itk-dev/drupal_webform_booking_module/pull/128)
+  for sunday from (7) to (0) [#236](https://github.com/itk-dev/os2forms_selvbetjening/pull/236)
 
 ## [2.6.2] 2023-10-13
 

--- a/web/modules/custom/itkdev_booking/assets/src/util/calendar-utils.js
+++ b/web/modules/custom/itkdev_booking/assets/src/util/calendar-utils.js
@@ -88,7 +88,7 @@ export function handleResources(value, currentCalendarDate) {
     const endTime = dayjs(v.close).format("HH:mm");
 
     const businessHours = {
-      daysOfWeek: [v.weekday],
+      daysOfWeek: [v.weekday === 7 ? 0 : v.weekday], // Sunday is internally defined as day 0, hence day 7 is converted to day 0 here.
       startTime: businessHoursOrNearestFifteenMinutes(startTime, currentCalendarDate, false),
       endTime,
     };


### PR DESCRIPTION
Link to ticket
https://jira.itkdev.dk/browse/SUPP0RT-1278

Description
Internally in Fullcalendar, sunday is defined as daysOfWeek[0], but we are defining it as daysOfWeek[7].
Hence, all resources are unavailable on sundays, as no businessHours exist.

This PR fixes this issue, by checking for day 7, converting it to day 0.
It does not seem possible to change the internal structure of this.

An alternative fix, could be to get MSB to update their SQL, but this solves the problem for now.