### PR TITLE
Hotfix/sunday businesshours convert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## In develop
 
+* Converted internal notation of business hours
+  for sunday from (7) to (0)
+
 ## [2.6.2] 2023-10-13
 
 * Opdaterede `composer.lock`-hash

--- a/web/modules/custom/itkdev_booking/assets/src/util/calendar-utils.js
+++ b/web/modules/custom/itkdev_booking/assets/src/util/calendar-utils.js
@@ -88,7 +88,7 @@ export function handleResources(value, currentCalendarDate) {
     const endTime = dayjs(v.close).format("HH:mm");
 
     const businessHours = {
-      daysOfWeek: [v.weekday],
+      daysOfWeek: [v.weekday === 7 ? 0 : v.weekday], // Sunday is internally defined as day 0, hence day 7 is converted to day 0 here.
       startTime: businessHoursOrNearestFifteenMinutes(startTime, currentCalendarDate, false),
       endTime,
     };


### PR DESCRIPTION
Link to ticket
https://jira.itkdev.dk/browse/SUPP0RT-1278

Description
Internally in Fullcalendar, sunday is defined as daysOfWeek[0], but we are defining it as daysOfWeek[7].
Hence, all resources are unavailable on sundays, as no businessHours exist.

This PR fixes this issue, by checking for day 7, converting it to day 0.
It does not seem possible to change the internal structure of this.

An alternative fix, could be to get MSB to update their SQL, but this solves the problem for now.