### PR TITLE
Added 4xx page template with logout link in default theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## In develop
 
-* Tilføjede 4xx page template med logout link 
+* Tilføjede 4xx page template med logout link
 (<https://github.com/itk-dev/os2forms_selvbetjening/pull/258>)
 * Opdaterede til [OS2Forms
   3.13.3](https://github.com/OS2Forms/os2forms/releases/tag/3.13.3).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## In develop
 
-* Tilføjede 4xx page template med logout link
+* Tilføjede 4xx page template med logout link 
+(<https://github.com/itk-dev/os2forms_selvbetjening/pull/258>)
 * Opdaterede til [OS2Forms
   3.13.3](https://github.com/OS2Forms/os2forms/releases/tag/3.13.3).
 * Tilføjede praktiske CPR- og CVR-opslagskommandoer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## In develop
 
+* Tilføjede 4xx page template med logout link
 * Opdaterede til [OS2Forms
   3.13.3](https://github.com/OS2Forms/os2forms/releases/tag/3.13.3).
 * Tilføjede praktiske CPR- og CVR-opslagskommandoer.

--- a/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
+++ b/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
@@ -7,6 +7,6 @@
  */
 function os2forms_selvbetjening_theme_preprocess_page(&$variables): void {
   $variables['site_logo'] = theme_get_setting('logo.url');
-  $variables['siteName'] =  \Drupal::config('system.site')->get('name');
+  $variables['siteName'] = \Drupal::config('system.site')->get('name');
   $variables['requestUri'] = \Drupal::service('request_stack')->getCurrentRequest()->getRequestUri();
 }

--- a/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
+++ b/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
@@ -7,6 +7,6 @@
  */
 function os2forms_selvbetjening_theme_preprocess_page(&$variables): void {
   $variables['site_logo'] = theme_get_setting('logo.url');
-  $variables['siteName'] = \Drupal::config('system.site')->get('name');
-  $variables['requestUri'] = \Drupal::service('request_stack')->getCurrentRequest()->getRequestUri();
+  $variables['site_name'] = \Drupal::config('system.site')->get('name');
+  $variables['request_uri'] = \Drupal::service('request_stack')->getCurrentRequest()->getRequestUri();
 }

--- a/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
+++ b/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
@@ -5,6 +5,8 @@
  *
  * Add site_logo value to page template.
  */
-function os2forms_selvbetjening_theme_preprocess_page(&$variables) {
+function os2forms_selvbetjening_theme_preprocess_page(&$variables): void {
   $variables['site_logo'] = theme_get_setting('logo.url');
+  $variables['siteName'] =  \Drupal::config('system.site')->get('name');
+  $variables['requestUri'] = \Drupal::service('request_stack')->getCurrentRequest()->getRequestUri();
 }

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
@@ -5,7 +5,7 @@
   {{ page.content }}
   {% if logged_in %}
     <p>
-      Her er et forslag til hvad du kan gøre. Prøv at logge ud af <a href="/user/logout?destination={{ requestUri }}">{{ siteName }}</a>
+      {{ 'Here is a suggestion to what you can do. Try to log out of <a href="/user/logout?destination=@requestUri">@siteName</a>'|t({'@requestUri': requestUri, '@siteName': siteName}) }}
     </p>
   {% endif %}
 {% endblock %}

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
@@ -5,7 +5,8 @@
   {{ page.content }}
   {% if logged_in %}
     <p>
-      {{ 'Here is a suggestion to what you can do. Try to log out of <a href="/user/logout?destination=@requestUri">@siteName</a>'|t({'@requestUri': requestUri, '@siteName': siteName}) }}
+      {% set url = path('/user/logout', {destination: requestUri}) %}
+      {{ 'Here is a suggestion to what you can do. Try to log out of <a href=":url">@siteName</a>'|t({':url': url, '@siteName': siteName}) }}
     </p>
   {% endif %}
 {% endblock %}

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
@@ -1,0 +1,11 @@
+{% extends "page.html.twig" %}
+
+{# Content #}
+{% block page_content %}
+  {{ page.content }}
+  {% if logged_in %}
+    <p>
+      Her er et forslag til hvad du kan gøre. Prøv at logge ud af <a href="/user/logout?destination={{ requestUri }}">{{ siteName }}</a>
+    </p>
+  {% endif %}
+{% endblock %}

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page--4xx.html.twig
@@ -5,8 +5,8 @@
   {{ page.content }}
   {% if logged_in %}
     <p>
-      {% set url = path('/user/logout', {destination: requestUri}) %}
-      {{ 'Here is a suggestion to what you can do. Try to log out of <a href=":url">@siteName</a>'|t({':url': url, '@siteName': siteName}) }}
+      {% set url = path('/user/logout', {destination: request_uri}) %}
+      {{ 'Here is a suggestion to what you can do. Try to log out of <a href=":url">@siteName</a>'|t({':url': url, '@siteName': site_name}) }}
     </p>
   {% endif %}
 {% endblock %}

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/page/page.html.twig
@@ -21,7 +21,9 @@
         {{ page.help }}
       </div>
     {% endif %}
-    {{ page.content }}
+    {% block page_content %}
+      {{ page.content }}
+    {% endblock %}
   </main>
 </div>
 


### PR DESCRIPTION
https://jira.itkdev.dk/browse/SUPP0RT-1356

Der findes template suggestions til 4xx pages med drupal core:
https://www.drupal.org/node/2363987

I første omgang har jeg bare lavet en generel template der fanger alle 4xx kald, men den kan gøres mere specifik.
Det hele er lagt i temaet fornu. Hvis der på et tidspunkt skal til os2, er der muligvis brug for modul med konfiguration etc.
