### PR TITLE
FORMS-410: Revert organisation upgrade

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -129,9 +129,6 @@ jobs:
       - name: Setup docker network
         run: docker network create frontend
 
-      - name: Setup docker network
-        run: docker network create serviceplatformen_organisation_api_app
-
       - name: Install build dependencies
         run: docker compose run --rm node yarn --cwd /app/web/themes/custom/os2forms_selvbetjening_theme install
 
@@ -146,9 +143,6 @@ jobs:
 
       - name: Setup docker network
         run: docker network create frontend
-
-      - name: Setup docker network
-        run: docker network create serviceplatformen_organisation_api_app
 
       - name: Install build dependencies
         run: docker compose run --rm node yarn --cwd /app/web/themes/custom/os2forms_selvbetjening_theme install
@@ -168,7 +162,6 @@ jobs:
       - name: Install site
         run: |
           docker network create frontend
-          docker network create serviceplatformen_organisation_api_app
           docker compose pull
           docker compose up --detach
 

--- a/README.md
+++ b/README.md
@@ -116,14 +116,6 @@ We use [Webform REST](https://www.drupal.org/project/webform_rest) to expose a
 number of API endpoints. See [OS2Forms REST
 API](web/modules/custom/os2forms_rest_api/README.md) for details.
 
-### Organisation API
-
-Configure organisation API endpoint on `/admin/os2forms_organisation/settings` to
-
-```sh
-http://organisation_api:8080/api/v1/
-```
-
 ## Production
 
 ```sh

--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
         "itk-dev/web_accessibility_statement": "^1.0",
         "os2forms/os2forms_forloeb_profile": "^1.12",
         "os2forms/os2forms_get_organized": "^1.1.5",
-        "os2forms/os2forms_organisation": "dev-main",
+        "os2forms/os2forms_organisation": "^1.3",
         "os2forms/os2forms_rest_api": "^2.0",
         "os2forms/os2forms_sync": "^1.1.2",
         "os2forms/os2forms_webform_submission_log": "^1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0877a6ce4f3922ae6b4d5f151d332ff1",
+    "content-hash": "c215b61606392eab0ee3ea9b8ad090cc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9942,16 +9942,16 @@
         },
         {
             "name": "os2forms/os2forms_organisation",
-            "version": "dev-main",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itk-dev/os2forms_organisation.git",
-                "reference": "5ba6b08f08bb1bda1997df300ef259c313cb19c5"
+                "reference": "ef637aaa2391ee075e96e9e99beabd1c40701a3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/itk-dev/os2forms_organisation/zipball/5ba6b08f08bb1bda1997df300ef259c313cb19c5",
-                "reference": "5ba6b08f08bb1bda1997df300ef259c313cb19c5",
+                "url": "https://api.github.com/repos/itk-dev/os2forms_organisation/zipball/ef637aaa2391ee075e96e9e99beabd1c40701a3d",
+                "reference": "ef637aaa2391ee075e96e9e99beabd1c40701a3d",
                 "shasum": ""
             },
             "require": {
@@ -9967,7 +9967,6 @@
                 "mglaman/drupal-check": "^1.4",
                 "phpunit/phpunit": "^9.5"
             },
-            "default-branch": true,
             "type": "drupal-module",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -9982,9 +9981,9 @@
             "description": "OS2Forms organisation",
             "support": {
                 "issues": "https://github.com/itk-dev/os2forms_organisation/issues",
-                "source": "https://github.com/itk-dev/os2forms_organisation/tree/main"
+                "source": "https://github.com/itk-dev/os2forms_organisation/tree/1.3.3"
             },
-            "time": "2023-12-20T10:52:14+00:00"
+            "time": "2023-10-24T07:45:53+00:00"
         },
         {
             "name": "os2forms/os2forms_rest_api",
@@ -22297,8 +22296,7 @@
     ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "itk-dev/serviceplatformen": 20,
-        "os2forms/os2forms_organisation": 20
+        "itk-dev/serviceplatformen": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,15 +1,6 @@
 # https://github.com/Soluto/oidc-server-mock
 
-networks:
-  organisation_api:
-    external: true
-    name: serviceplatformen_organisation_api_app
-
 services:
-  phpfpm:
-    networks:
-      - organisation_api
-
   node:
     image: node:16
     profiles:

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -1,9 +1,6 @@
 version: "3"
 
 networks:
-  organisation_api:
-    external: true
-    name: serviceplatformen_organisation_api_app
   frontend:
     external: true
   app:
@@ -13,8 +10,6 @@ networks:
 
 services:
   phpfpm:
-    networks:
-      - organisation_api
     environment:
       - PHP_MAX_EXECUTION_TIME=30
       - PHP_MEMORY_LIMIT=512M


### PR DESCRIPTION
https://leantime.itkdev.dk/tickets/showKanban?search=true&projectId=41&sprint=all#/tickets/showTicket/410

* Reverts organisation upgrade changes made in release branch (https://github.com/itk-dev/os2forms_selvbetjening/pull/259)


`CHANGELOG.md` was not updated with an entry for the `os2forms_organisation` upgrade in the `release/2.7.1`-branch, hence the non-updated changelog.