### PR TITLE
Release/2.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
+## [2.7.6] 2024-02-05
+
+* Opdaterede flow opgave notifikationstilladelser.
+
 ## [2.7.5] 2024-01-29
 
 * Tilføjede logout link på flow siden.
@@ -397,7 +401,8 @@ og [OS2Forms 3.7.0](https://github.com/OS2Forms/os2forms/releases/tag/3.7.0)
 
 * GO borgersager
 
-[Under udvikling]: https://github.com/itk-dev/os2forms_selvbetjening/compare/2.7.5...HEAD
+[Under udvikling]: https://github.com/itk-dev/os2forms_selvbetjening/compare/2.7.6...HEAD
+[2.7.6]: https://github.com/itk-dev/os2forms_selvbetjening/compare/2.7.5...2.7.6
 [2.7.5]: https://github.com/itk-dev/os2forms_selvbetjening/compare/2.7.4...2.7.5
 [2.7.4]: https://github.com/itk-dev/os2forms_selvbetjening/compare/2.7.3...2.7.4
 [2.7.3]: https://github.com/itk-dev/os2forms_selvbetjening/compare/2.7.2...2.7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
-## [2.7.6] 2024-02-05
+## [2.7.6] 2024-02-06
 
 * Opdaterede flow opgave notifikationstilladelser.
 

--- a/composer.json
+++ b/composer.json
@@ -144,7 +144,8 @@
                 "Change check for node form": "patches/drupal/permissions_by_term/changeNodeCheck.patch"
             },
             "drupal/maestro": {
-                "Disallow empty queueToken": "patches/drupal/maestro/maestro_token.patch"
+                "Disallow empty queueToken": "patches/drupal/maestro/maestro_token.patch",
+                "Maestro task notification permission patch": "patches/drupal/maestro/maestro_task_select_notification_role_permission.patch"
             }
         },
         "patches-ignore": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2400870b678b61f21bf88655e2617892",
+    "content-hash": "55e9190c698c3d94715baa95b25038f5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4343,6 +4343,10 @@
                 {
                     "name": "gauravsood91",
                     "homepage": "https://www.drupal.org/user/3288491"
+                },
+                {
+                    "name": "shashank_thigale",
+                    "homepage": "https://www.drupal.org/user/3632808"
                 }
             ],
             "description": "Drupal LDAP / Active Directory Integration module allows your users to log in to your Drupal site using their LDAP / AD credentials. In addition to LDAP, this module also allows you to log in using NTLM and Kerberos",
@@ -5895,12 +5899,16 @@
             ],
             "authors": [
                 {
-                    "name": "Sam Hermans",
-                    "homepage": "https://www.drupal.org/user/1867966"
+                    "name": "AstonVictor",
+                    "homepage": "https://www.drupal.org/user/3466615"
                 },
                 {
                     "name": "jrreid",
                     "homepage": "https://www.drupal.org/user/70645"
+                },
+                {
+                    "name": "Sam Hermans",
+                    "homepage": "https://www.drupal.org/user/1867966"
                 },
                 {
                     "name": "wouters_f",
@@ -6073,10 +6081,6 @@
                 {
                     "name": "Berdir",
                     "homepage": "https://www.drupal.org/user/214652"
-                },
-                {
-                    "name": "Dane Powell",
-                    "homepage": "https://www.drupal.org/user/339326"
                 },
                 {
                     "name": "gielfeldt",
@@ -6689,6 +6693,10 @@
                 {
                     "name": "nsalves",
                     "homepage": "https://www.drupal.org/user/3557178"
+                },
+                {
+                    "name": "pmaiacar",
+                    "homepage": "https://www.drupal.org/user/3575425"
                 }
             ],
             "description": "Allows retrieving webform elements and submitting webforms via REST",
@@ -10714,6 +10722,7 @@
                 "issues": "https://github.com/php-http/guzzle6-adapter/issues",
                 "source": "https://github.com/php-http/guzzle6-adapter/tree/v2.0.2"
             },
+            "abandoned": "guzzlehttp/guzzle or php-http/guzzle7-adapter",
             "time": "2021-03-02T10:52:33+00:00"
         },
         {
@@ -21876,12 +21885,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
@@ -21926,6 +21935,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
             "time": "2023-02-22T23:07:41+00:00"
         },
         {

--- a/patches/drupal/maestro/maestro_task_select_notification_role_permission.patch
+++ b/patches/drupal/maestro/maestro_task_select_notification_role_permission.patch
@@ -1,0 +1,17 @@
+diff --git a/src/MaestroTaskTrait.php b/src/MaestroTaskTrait.php
+index 9aefd9e..0133e0d 100644
+--- a/src/MaestroTaskTrait.php
++++ b/src/MaestroTaskTrait.php
+@@ -312,10 +312,10 @@ trait MaestroTaskTrait {
+ 
+     $form['edit_task_notifications']['select_notification_role'] = [
+       '#id' => 'select_notification_role',
+-      '#type' => 'textfield',
++      '#type' => 'entity_autocomplete',
++      '#target_type' => 'user_role',
+       '#default_value' => '',
+       '#title' => $this->t('Role'),
+-      '#autocomplete_route_name' => 'maestro.autocomplete.roles',
+       '#required' => FALSE,
+       '#prefix' => '<div class="maestro-engine-notifications-hidden-role">',
+       '#suffix' => '</div></div>',


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/592

Release 2.7.6

Hotfixes https://github.com/OS2Forms/os2forms/pull/85

**Should be removed when os2forms/os2forms is updated**

* Maestro flow task notification role permission patch

Currently, users need the `administer site configuration` permission to configure notification on flows, whereas assigning the task does not. Patch updates the notification configuration (`select_notification_role`) to behave in the same manner as the assignment configuration (`select_assigned_role`) to align the two.