### PR TITLE
#779: Added pattern checks and error emails to email handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@
 !/web/modules/custom/os2forms_user_menu
 !/web/modules/custom/os2forms_fbs_handler
 !/web/modules/custom/os2forms_permission_alterations
+!/web/modules/custom/os2forms_email
 
 # Ignore site specific modules.
 /web/sites/*/modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 ## [Under udvikling]
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
+* Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
 
 ## [2.7.7] 2024-02-15
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ http://organisation_api:8080/api/v1/
 
 ### OS2Forms Email
 
-Overrides default webform email handler adding the opportunity for extra check on email recipient.
+Overrides default webform email handler
+adding the ability to do an extra check on email recipient.
 Allows for sending emails to webform owner if recipient email is not valid.
 
 By default, none of these extra steps are done.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,25 @@ Configure organisation API endpoint on `/admin/os2forms_organisation/settings` t
 http://organisation_api:8080/api/v1/
 ```
 
+### OS2Forms Email
+
+Overrides default webform email handler adding the opportunity for extra check on email recipient.
+Allows for sending emails to webform owner if recipient email is not valid.
+
+By default, none of these extra steps are done.
+Enable and configure them by setting the following in `settings.local.php`:
+
+```php
+// OS2Forms email
+$config['os2forms_email']['pattern_enable'] = TRUE;
+$config['os2forms_email']['pattern'] = '/.*@aarhus\.dk$/';
+$config['os2forms_email']['error_message_enable'] = TRUE;
+$config['os2forms_email']['error_message_subject'] = 'Email forsendelse fejlet';
+$config['os2forms_email']['error_message_body'] = "<p>Kære @owner</p><p>@body</p>";
+$config['os2forms_email']['error_message_from_email'] = 'noreply@aarhus.dk';
+$config['os2forms_email']['error_message_from_name'] = 'Selvbetjening';
+```
+
 ## Production
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ Enable and configure them by setting the following in `settings.local.php`:
 $config['os2forms_email']['pattern_enable'] = TRUE;
 $config['os2forms_email']['pattern'] = '/.*@aarhus\.dk$/';
 $config['os2forms_email']['error_message_enable'] = TRUE;
-$config['os2forms_email']['error_message_subject'] = 'Email forsendelse fejlet';
-$config['os2forms_email']['error_message_body'] = "<p>Kære @owner</p><p>@body</p>";
 $config['os2forms_email']['error_message_from_email'] = 'noreply@aarhus.dk';
 $config['os2forms_email']['error_message_from_name'] = 'Selvbetjening';
 ```
+
+Remember to translate the error message email subject and body.
 
 ## Production
 

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -77,6 +77,7 @@ module:
   os2forms_attachment: 0
   os2forms_dawa: 0
   os2forms_digital_post: 0
+  os2forms_email: 0
   os2forms_failed_jobs: 0
   os2forms_fbs_handler: 0
   os2forms_forloeb: 0

--- a/web/modules/custom/os2forms_email/os2forms_email.info.yml
+++ b/web/modules/custom/os2forms_email/os2forms_email.info.yml
@@ -1,0 +1,7 @@
+name: 'OS2Forms email'
+type: module
+description: 'Overrides email handler adding extra checks and functionality'
+package: 'OS2Forms'
+core_version_requirement: ^9
+dependencies:
+  - 'webform:webform'

--- a/web/modules/custom/os2forms_email/os2forms_email.module
+++ b/web/modules/custom/os2forms_email/os2forms_email.module
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Module file for the os2forms_email module.
+ */
+
+use Drupal\os2forms_email\Plugin\WebformHandler\OS2FormsEmailWebformHandler;
+
+/**
+ * Implements hook_ELEMENT_info_alter().
+ *
+ * Overrides default webform email handler with OS2FormsEmailWebformHandler.
+ */
+function os2forms_email_webform_handler_info_alter(array &$handlers): void {
+  $handlers['email']['class'] = OS2FormsEmailWebformHandler::class;
+}

--- a/web/modules/custom/os2forms_email/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
+++ b/web/modules/custom/os2forms_email/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\os2forms_email\Plugin\WebformHandler;
+
+use Drupal\webform\Plugin\WebformHandler\EmailWebformHandler;
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ * Emails a webform submission.
+ *
+ * @WebformHandler(
+ *   id = "email",
+ *   label = @Translation("OS2Forms email"),
+ *   category = @Translation("Notification"),
+ *   description = @Translation("Sends a webform submission via an email."),
+ *   cardinality = \Drupal\webform\Plugin\WebformHandlerInterface::CARDINALITY_UNLIMITED,
+ *   results = \Drupal\webform\Plugin\WebformHandlerInterface::RESULTS_PROCESSED,
+ *   tokens = TRUE,
+ * )
+ */
+class OS2FormsEmailWebformHandler extends EmailWebformHandler {
+
+  /**
+   * Adds extra check to to_mail before sending message.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
+   *   A webform submission.
+   * @param array $message
+   *   An array of message parameters.
+   *
+   * @throws \Drupal\Core\Entity\EntityMalformedException
+   */
+  public function sendMessage(WebformSubmissionInterface $webform_submission, array $message) {
+
+    if (!$this->configFactory->get('os2forms_email')->get('pattern_enable')) {
+      return parent::sendMessage($webform_submission, $message);
+    }
+
+    $pattern = $this->configFactory->get('os2forms_email')->get('pattern');
+    $emailAddress = $message['to_mail'];
+
+    if (!filter_var($emailAddress, FILTER_VALIDATE_EMAIL) || !preg_match($pattern, $emailAddress)) {
+
+      $context = [
+        '@form' => $this->getWebform()->label(),
+        '@handler' => $this->label(),
+        '@email' => $emailAddress,
+        'link' => ($webform_submission->id()) ? $webform_submission->toLink($this->t('View'))->toString() : NULL,
+        'webform_submission' => $webform_submission,
+        'handler_id' => $this->getHandlerId(),
+        'operation' => 'failed sending email',
+      ];
+
+      if ($webform_submission->getWebform()->hasSubmissionLog()) {
+        // Log detailed message to the 'webform_submission' log.
+        $this->getLogger('webform_submission')->notice("Email not sent for '@handler' handler because the email (@email) is not valid.", $context);
+      }
+
+      $this->sendMessageToWebformAuthor($webform_submission, $message, $context);
+
+      return FALSE;
+    }
+
+    return parent::sendMessage($webform_submission, $message);
+  }
+
+  /**
+   * Sends message to webform author.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
+   *   A webform submission.
+   * @param array $message
+   *   An array of message parameters.
+   * @param array $context
+   *   An array with context.
+   */
+  private function sendMessageToWebformAuthor(WebformSubmissionInterface $webform_submission, array $message, array $context): void {
+
+    if (!$this->configFactory->get('os2forms_email')->get('error_message_enable')) {
+      return;
+    }
+
+    $pattern = $this->configFactory->get('os2forms_email')->get('pattern');
+    $authorEmail = $webform_submission->getWebform()->getOwner()->getEmail();
+
+    if (!filter_var($authorEmail, FILTER_VALIDATE_EMAIL) || !preg_match($pattern, $authorEmail)) {
+      // Cannot send email to author email. Log it and give up.
+      if ($webform_submission->getWebform()->hasSubmissionLog()) {
+
+        $authorMessageContext = $context;
+        $authorMessageContext['@email'] = $authorEmail;
+
+        $this->getLogger('webform_submission')->notice("Email not sent for '@handler' handler because the email (@email) is not valid.", $authorMessageContext);
+      }
+
+      return;
+    }
+
+    $errorMessage = $this->defaultConfiguration();
+
+    $errorMessage['to_mail'] = $authorEmail;
+    $errorMessage['subject'] = $this->configFactory->get('os2forms_email')->get('error_message_subject');
+
+    $body = sprintf(
+      "Email not sent for handler (%s) on formular (%s) because the email (%s) is not valid.",
+      $context['@handler'],
+      $context['@form'],
+      $context['@email']
+    );
+
+    $errorMessage['body'] = sprintf('<p>Kære %s</p><p>%s</p>', $webform_submission->getWebform()->getOwner()->getDisplayName(), $body);
+    $errorMessage['from_mail'] = $this->configFactory->get('os2forms_email')->get('error_message_from_email');
+    $errorMessage['from_name'] = $this->configFactory->get('os2forms_email')->get('error_message_from_name');
+    $errorMessage['webform_submission'] = $message['webform_submission'];
+    $errorMessage['handler'] = $message['handler'];
+
+    parent::sendMessage($webform_submission, $errorMessage);
+  }
+
+}

--- a/web/modules/custom/os2forms_email/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
+++ b/web/modules/custom/os2forms_email/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
@@ -113,16 +113,16 @@ class OS2FormsEmailWebformHandler extends EmailWebformHandler {
     $errorMessage = $this->defaultConfiguration();
 
     $errorMessage['to_mail'] = $authorEmail;
-    $errorMessage['subject'] = $this->configFactory->get('os2forms_email')->get('error_message_subject');
+    $errorMessage['subject'] = $this->t('Sending email failed');
 
-    $body = sprintf(
-      "Email not sent for handler (%s) on formular (%s) because the email (%s) is not valid.",
-      $context['@handler'],
-      $context['@form'],
-      $context['@email']
-    );
+    $errorMessage['body'] = $this->t(
+      "<p>Dear @name</p><p>Email not sent for handler (@handler) on form (@form) because the email (@email) is not valid.</p>", [
+        '@name' => $webform_submission->getWebform()->getOwner()->getDisplayName(),
+        '@handler' => $context['@handler'] ?? '',
+        '@form' => $context['@form'] ?? '',
+        '@email' => $context['@email'] ?? '',
+      ]);
 
-    $errorMessage['body'] = sprintf('<p>Kære %s</p><p>%s</p>', $webform_submission->getWebform()->getOwner()->getDisplayName(), $body);
     $errorMessage['from_mail'] = $this->configFactory->get('os2forms_email')->get('error_message_from_email');
     $errorMessage['from_name'] = $this->configFactory->get('os2forms_email')->get('error_message_from_name');
     $errorMessage['webform_submission'] = $message['webform_submission'];


### PR DESCRIPTION
https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/779

* Overrides default email handler
  *  Adds ability to deny emails by supplying a regexp pattern that must match `to_mail`
  * Adds ability to send email to webform owner if email is invalid
  * Adds entry in 'webform_submission' log (`/admin/structure/webform/manage/{weform_id}/results/log`) if email cannot be send 