### PR TITLE
#1040: Updated maestro flow task menu styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
+* Opdaterede styling på maestro flow task menu.
 
 ## [2.7.8] 20-24-03-08
 

--- a/web/sites/default/files/gin-custom.css
+++ b/web/sites/default/files/gin-custom.css
@@ -59,3 +59,22 @@ ul.toolbar-menu {
   scrollbar-width: none;
   scroll-margin: 0px;
 }
+
+/*
+* Maestro - Task Menu close icon.
+*
+* Make it visible to the human eye.
+*/
+.ui-widget-content .ui-icon, .ui-widget-header .ui-icon {
+  background-image: url(../../../core/themes/claro/images/ui-icons-ffffff-256x240.png);
+}
+
+.ui-dialog .ui-dialog-titlebar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+#maestro-task-menu > div {
+  padding: 15px 15px 15px 15px;
+}


### PR DESCRIPTION
https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/1040

* Updates maestro flow task menu close icon to be human visible when using the gin administration theme.

Before: 
<img width="1472" alt="flow_task_menu_before" src="https://github.com/itk-dev/os2forms_selvbetjening/assets/78410897/87f4616a-65ab-4e8d-b3c2-79f22a95ee73">

After:
<img width="1472" alt="flow_task_menu_after" src="https://github.com/itk-dev/os2forms_selvbetjening/assets/78410897/25e46365-a860-4cd9-b996-4dc90c25b74d">
