### PR TITLE
#1039: Added Maestro notification pdf template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
-* Tilføjede Maestro notifikation pdf template.
+* Tilføjede templates til `os2forms_attachment` og maestro pdf notifikationer
+  i `os2forms_selvbetjening_theme` temaet, som nemmere kan justeres.
 
 ## [2.7.8] 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
-* Tilføjede templates til ændring af `os2forms_attachment` og maestro pdf
-  notifikationer i `os2forms_selvbetjening_theme` temaet.
+* Tilføjede templates til ændring af `os2forms_attachment` og maestro-pdf-notifikationer i `os2forms_selvbetjening_theme`-temaet.
 
 ## [2.7.8] 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
+* Tilføjede Maestro notifikation pdf template.
 
-## [2.7.8] 20-24-03-08
+## [2.7.8] 2024-03-08
 
 * Opdaterede til [OS2Forms NemLogin OpenID Connect
   2.0.1](https://github.com/itk-dev/os2forms_nemlogin_openid_connect/releases/tag/2.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
-* Tilføjede templates til ændring af `os2forms_attachment` og maestro-pdf-notifikationer i `os2forms_selvbetjening_theme`-temaet.
+* Tilføjede templates til ændring af `os2forms_attachment` og
+  maestro-pdf-notifikationer i `os2forms_selvbetjening_theme`-temaet.
 
 ## [2.7.8] 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
-* Tilføjede templates til `os2forms_attachment` og maestro pdf notifikationer
-  i `os2forms_selvbetjening_theme` temaet, som nemmere kan justeres.
+* Tilføjede templates til ændring af `os2forms_attachment` og maestro pdf
+  notifikationer i `os2forms_selvbetjening_theme` temaet.
 
 ## [2.7.8] 2024-03-08
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -804,7 +804,7 @@ $settings['config_sync_directory'] = '../config/sync';
 /**
  * Base url.
  *
- * Used to generate full path to stylesheets in os2forms_selvbetjening_theme.
+ * Used to generate full URL to stylesheets in os2forms_selvbetjening_theme.
  */
 $settings['base_url'] = 'http://nginx:8080';
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -802,6 +802,13 @@ $databases['default']['default'] = [
 $settings['config_sync_directory'] = '../config/sync';
 
 /**
+ * Base url.
+ *
+ * Used to generate full path to stylesheets in os2forms_selvbetjening_theme.
+ */
+$settings['base_url'] = 'http://nginx:8080';
+
+/**
  * Load local development override configuration, if available.
  *
  * Create a settings.local.php file to override variables on secondary (staging,

--- a/web/themes/custom/os2forms_selvbetjening_theme/README.md
+++ b/web/themes/custom/os2forms_selvbetjening_theme/README.md
@@ -1,5 +1,35 @@
 # selvbetjening.aarhuskommune.dk
 
+## PDF templates
+
+To override PDF templates sent via Digital Post, we have added
+`os2forms-attachment--webform-submission.html.twig` and
+`os2forms-selvbetjening-maestro-notification-pdf-html.html.twig`
+to overwrite os2forms attachment and maestro notification (pdf) html
+respectively.
+
+The maestro notification pdf template should be configured on
+`admin/config/system/os2forms_forloeb` as
+
+```sh
+themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-selvbetjening-maestro-notification-pdf-html.html.twig
+```
+
+whereas the os2forms attachment template automatically should be used.
+
+To allow usage of a common stylesheet in the two templates you
+must configure `base_url` in `settings.local.php`
+
+```php
+$settings['base_url'] = 'http://nginx:8080';
+```
+
+and disable default css in the entity print module. This is done by
+unchecking `Enable Default CSS` on `admin/config/content/entityprint`.
+
+
+## Theme usage
+
 ```sh
 docker-compose run --rm node yarn --cwd /app/web/themes/custom/os2forms_selvbetjening_theme install
 docker-compose run --rm node yarn --cwd /app/web/themes/custom/os2forms_selvbetjening_theme build

--- a/web/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css
+++ b/web/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css
@@ -5,7 +5,6 @@
 body {
   font-family:"DejaVu Sans",Helvetica,Arial,sans-serif;
   margin: 0;
-  color: red;
 }
 
 header {

--- a/web/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css
+++ b/web/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css
@@ -1,5 +1,6 @@
 @page {
-  margin: 180px 35px 150px 35px;
+  size: A4;
+  margin: 180px 35px 150px 35px;  
 }
 
 body {

--- a/web/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css
+++ b/web/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css
@@ -1,0 +1,137 @@
+@page {
+  margin: 180px 35px 150px 35px;
+}
+
+body {
+  font-family:"DejaVu Sans",Helvetica,Arial,sans-serif;
+  margin: 0;
+  color: red;
+}
+
+header {
+  position: fixed;
+  top: -150px;
+  left: 25px;
+  right: 0px;
+  height: 50px;
+  font-size: 12px;
+}
+
+footer {
+  position: fixed;
+  bottom: -50px;
+  left: 25px;
+  right: 0px;
+  height: 50px;
+  font-size: 12px;
+}
+
+details {
+  border:1px solid #ccc;
+  margin-top:1em;
+  margin-bottom:1em;
+}
+
+summary {
+  font-size: 20px !important;
+  font-weight:bold;
+  padding:.5em .5em 0 .5em;
+}
+
+summary::marker {
+  display:none;
+}
+
+legend, summary, .details-wrapper, fieldset {
+  padding: 0;
+}
+
+fieldset {
+  margin: 0;
+  border: 0;
+}
+
+.page {
+  padding:20px;
+}
+
+.page img {
+  max-width:100%;height:auto;
+}
+
+.page td img {
+  max-width:none;
+}
+
+.details-wrapper {
+  padding:0 1em;
+}
+
+.form-item {
+  margin-top:1em;
+  margin-bottom:1em;
+}
+
+label {
+  display:block;
+  font-weight:bold;
+}
+
+thead {
+  border-bottom: 1px solid black;
+}
+
+th {
+  text-align: left;
+}
+
+details, .claro-details {
+  border: none !important;
+}
+
+.webform-submission-table {
+  width:100%;
+  border-collapse:collapse;
+  border-spacing:0;
+}
+
+.webform-submission-table th {
+  width:33%;
+  min-width:100px;
+}
+
+.webform-submission-table th,
+.webform-submission-table td {
+  text-align:left;
+  padding:10px 12px;
+}
+
+.webform-submission-table tr {
+  border-top:1px solid #ccc;
+  border-bottom:1px solid #ccc;
+  padding:0.1em 0.6em;
+}
+
+.webform-entity-print-body {
+  font-size: 14px;
+  width: 65% !important;
+}
+
+.webform-element {
+  padding: 5px 0;
+  margin: 5px 0;
+  font-size: 12px;
+}
+
+.webform-entity-print-colophon {
+  font-size: 12px;
+  margin-top: -11px;
+}
+
+.webform-section-title {
+  font-size: 14px !important;
+}
+
+.table {
+  width: 100%;
+}

--- a/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
+++ b/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
@@ -1,7 +1,5 @@
 <?php
 
-use Drupal\Core\Site\Settings;
-
 /**
  * Implements hook_preprocess_page().
  *
@@ -10,13 +8,4 @@ use Drupal\Core\Site\Settings;
 function os2forms_selvbetjening_theme_preprocess_page(&$variables): void {
   $variables['site_logo'] = theme_get_setting('logo.url');
   $variables['site_name'] = \Drupal::config('system.site')->get('name');
-}
-
-/**
- * Implements hook_preprocess().
- *
- * Add 'base_url' variable to be used by templates.
- */
-function os2forms_selvbetjening_theme_preprocess(&$vars) {
-  $vars['base_url'] = Settings::get('base_url');
 }

--- a/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
+++ b/web/themes/custom/os2forms_selvbetjening_theme/os2forms_selvbetjening_theme.theme
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Site\Settings;
+
 /**
  * Implements hook_preprocess_page().
  *
@@ -8,4 +10,13 @@
 function os2forms_selvbetjening_theme_preprocess_page(&$variables): void {
   $variables['site_logo'] = theme_get_setting('logo.url');
   $variables['site_name'] = \Drupal::config('system.site')->get('name');
+}
+
+/**
+ * Implements hook_preprocess().
+ *
+ * Add 'base_url' variable to be used by templates.
+ */
+function os2forms_selvbetjening_theme_preprocess(&$vars) {
+  $vars['base_url'] = Settings::get('base_url');
 }

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-attachment--webform-submission.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-attachment--webform-submission.html.twig
@@ -1,0 +1,28 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="description" content="{{ title }}">
+  <meta name="keywords" content="Selvbetjening">
+  <meta name="author" content="{{ author }}">
+  <title>{{ title }}</title>
+  <link rel="stylesheet" media="all" href="{{ base_url }}/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css" />
+</head>
+<body>
+{% if header %}
+<header>
+  {{ header }}
+</header>
+{% endif %}
+
+{% if footer %}
+  <footer>
+    {{ footer }}
+  </footer>
+{% endif %}
+
+<div class="page">
+  {{ content }}
+</div>
+
+</body>
+</html>

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-selvbetjening-maestro-notification-pdf-html.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-selvbetjening-maestro-notification-pdf-html.html.twig
@@ -1,0 +1,76 @@
+{#
+  Use this to style Maestro PDF notifications.
+
+  Set it on '/admin/config/system/os2forms_forloeb' PDF template,
+  i.e. 'themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-selvbetjening-maestro-notification-pdf-html.html.twig'.
+
+  This is a composition of
+  os2forms_attachment, os2forms-attachment--webform-submission.html.twig, and
+  os2forms_forloeb, os2forms-forloeb-notification-message-pdf-html.html.twig.
+
+/**
+ * @file
+ * Template for Maestro notification PDF.
+ *
+ * Available variables:
+ * - message: The notification message
+ *   - subject: the notification subject
+ *   - content: the notification content. Must be rendered as `processed_text`, i.e.:
+ *     @code
+ *       {{ {
+ *       '#type':   'processed_text',
+ *       '#text':    message.content.value,
+ *       '#format':  message.content.format,
+ *       } }}
+ *     @endcode
+ * - notification_type: The type of notification ()
+ * - task_url: URL of the task.
+ * - action_label: Optional label for the task action.
+ */
+#}
+<!doctype html>
+<html lang="da">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ message.subject }}</title>
+    <link rel="stylesheet" media="all" href="{{ base_url }}/themes/custom/os2forms_selvbetjening_theme/assets/pdf.css" />
+  </head>
+  <body>
+    <header>
+      <div class="webform-entity-print-header">
+        <p>
+          <img alt="Aarhus Kommune Logo" data-align="right" data-entity-type="" data-entity-uuid="" src="https://cdn.aarhus.dk/bundled/static/aak-logo.svg?hash=6780e75ca799a9b45bb0e51ff430010b" />
+          <br/>
+        </p>
+      </div>
+    </header>
+
+    <div class="page">
+      <div>
+        <div class="webform-entity-print-colophon" style="float:right;width:27%;margin-left:20px;word-wrap:break-word;">
+          <p>[webform_submission:completed:custom:d. F Y]</p>
+          <p><strong>Aarhus Kommune</strong><br />
+            Rådhuspladsen 2<br />
+            8000 Aarhus C</p>
+        </div>
+        <div class="webform-entity-print-body" style="width:70%;">
+          {# @see https://api.drupal.org/api/drupal/core%21modules%21filter%21filter.module/function/check_markup/9 #}
+          <div class="notification-content">
+            {{ {
+              '#type':   'processed_text',
+              '#text':    message.content.value,
+              '#format':  message.content.format,
+            } }}
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+  <style>
+    fieldset legend {
+      margin-left: -12px;
+    }
+  </style>
+</html>
+

--- a/web/themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-selvbetjening-maestro-notification-pdf-html.html.twig
+++ b/web/themes/custom/os2forms_selvbetjening_theme/templates/pdf/os2forms-selvbetjening-maestro-notification-pdf-html.html.twig
@@ -49,7 +49,7 @@
     <div class="page">
       <div>
         <div class="webform-entity-print-colophon" style="float:right;width:27%;margin-left:20px;word-wrap:break-word;">
-          <p>[webform_submission:completed:custom:d. F Y]</p>
+          <p>[current-date:custom:d. F Y]</p>
           <p><strong>Aarhus Kommune</strong><br />
             Rådhuspladsen 2<br />
             8000 Aarhus C</p>


### PR DESCRIPTION
https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/1039

**Depends on** https://github.com/OS2Forms/os2forms/pull/95

* Added templates for `os2forms_attachment` and maestro pdf notifications, which can be used to have a common styling between the two.

Notification before
<img width="853" alt="Screenshot 2024-03-27 at 09 38 18" src="https://github.com/itk-dev/os2forms_selvbetjening/assets/78410897/4313c871-4f47-4a2d-abaf-ae9046906005">


Notification after (and with the configuration changes)
<img width="853" alt="Screenshot 2024-04-02 at 09 30 51" src="https://github.com/itk-dev/os2forms_selvbetjening/assets/78410897/7d70ca34-333f-4184-af80-92132c1f69f1">


