### PR TITLE
#1044: Override maestro flow user autocomplete to select by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Tilføjede mulighed for ekstra tjek på email modtagere (@aarhus.dk).
+* Opdaterede Maestro flows user autocomplete til at søge på navn.
 
 ## [2.7.9] 2024-04-04
 

--- a/composer.json
+++ b/composer.json
@@ -146,7 +146,8 @@
             },
             "drupal/maestro": {
                 "Fix check for task notifications": "patches/drupal/maestro/maestro_notification.patch",
-                "Maestro task notification permission patch": "patches/drupal/maestro/maestro_task_select_notification_role_permission.patch"
+                "Maestro task notification permission patch": "patches/drupal/maestro/maestro_task_select_notification_role_permission.patch",
+                "Maestro flow task entity autocomplete patch": "patches/drupal/maestro/maestro_entity_autocomplete.patch"
             }
         },
         "patches-ignore": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b0aee64129c0071ad19537546c989ff",
+    "content-hash": "dc7a7486864b1c522686ec765ae9be28",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/drupal/maestro/maestro_entity_autocomplete.patch
+++ b/patches/drupal/maestro/maestro_entity_autocomplete.patch
@@ -1,0 +1,20 @@
+diff --git a/src/MaestroTaskTrait.php b/src/MaestroTaskTrait.php
+index 9aefd9e..7dcf666 100644
+--- a/src/MaestroTaskTrait.php
++++ b/src/MaestroTaskTrait.php
+@@ -196,6 +196,7 @@ trait MaestroTaskTrait {
+       '#type' => 'entity_autocomplete',
+       '#target_type' => 'user',
+       '#default_value' => '',
++      '#selection_handler' => 'default:user_by_name',
+       '#selection_settings' => ['include_anonymous' => FALSE],
+       '#title' => $this->t('User'),
+       '#required' => FALSE,
+@@ -303,6 +304,7 @@ trait MaestroTaskTrait {
+       '#type' => 'entity_autocomplete',
+       '#target_type' => 'user',
+       '#default_value' => '',
++      '#selection_handler' => 'default:user_by_name',
+       '#selection_settings' => ['include_anonymous' => FALSE],
+       '#title' => $this->t('User'),
+       '#required' => FALSE,

--- a/web/modules/custom/os2forms_selvbetjening/src/Plugin/EntityReferenceSelection/UserByNameSelection.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Plugin/EntityReferenceSelection/UserByNameSelection.php
@@ -15,16 +15,16 @@ use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
  *   weight = 1
  * )
  */
-class UserByNameSelection extends DefaultSelection
-{
+class UserByNameSelection extends DefaultSelection {
+
   /**
    * {@inheritdoc}
    *
-   * Heavily inspired by Drupal\user\Plugin\EntityReferenceSelection\UserSelection,
+   * Heavily inspired by
+   * Drupal\user\Plugin\EntityReferenceSelection\UserSelection,
    * with a slight modification to the field condition.
    */
-  protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS')
-  {
+  protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS') {
     $query = parent::buildEntityQuery($match_operator, $match_operator);
 
     $configuration = $this->getConfiguration();
@@ -52,4 +52,5 @@ class UserByNameSelection extends DefaultSelection
 
     return $query;
   }
+
 }

--- a/web/modules/custom/os2forms_selvbetjening/src/Plugin/EntityReferenceSelection/UserByNameSelection.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Plugin/EntityReferenceSelection/UserByNameSelection.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\os2forms_selvbetjening\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+
+/**
+ * Provides specific access control for the node entity type.
+ *
+ * @EntityReferenceSelection(
+ *   id = "default:user_by_name",
+ *   label = @Translation("User by name field selection"),
+ *   entity_types = {"user"},
+ *   group = "default",
+ *   weight = 1
+ * )
+ */
+class UserByNameSelection extends DefaultSelection
+{
+  /**
+   * {@inheritdoc}
+   *
+   * Heavily inspired by Drupal\user\Plugin\EntityReferenceSelection\UserSelection,
+   * with a slight modification to the field condition.
+   */
+  protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS')
+  {
+    $query = parent::buildEntityQuery($match_operator, $match_operator);
+
+    $configuration = $this->getConfiguration();
+
+    // Filter out the Anonymous user if the selection handler is configured to
+    // exclude it.
+    if (!$configuration['include_anonymous']) {
+      $query->condition('uid', 0, '<>');
+    }
+
+    if (isset($match)) {
+      $query->condition('field_name', $match, $match_operator);
+    }
+
+    // Filter by role.
+    if (!empty($configuration['filter']['role'])) {
+      $query->condition('roles', $configuration['filter']['role'], 'IN');
+    }
+
+    // Adding the permission check is sadly insufficient for users: core
+    // requires us to also know about the concept of 'blocked' and 'active'.
+    if (!$this->currentUser->hasPermission('administer users')) {
+      $query->condition('status', 1);
+    }
+
+    return $query;
+  }
+}


### PR DESCRIPTION
https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/1044

* Overrides maestro flow user autocomplete to select by name rather than email (which is the username on our User entity)