### PR TITLE
#1237: Added patch hiding additional os2forms settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Opdaterede Maestro flows user autocomplete til at søge på navn.
 * Opdaterede styling på maestro flow task menu.
+* Fjernede ekstra OS2Forms indstillingsfaneblad på formularer.
 
 ## [2.7.9] 2024-04-04
 

--- a/composer.json
+++ b/composer.json
@@ -148,6 +148,9 @@
                 "Fix check for task notifications": "patches/drupal/maestro/maestro_notification.patch",
                 "Maestro task notification permission patch": "patches/drupal/maestro/maestro_task_select_notification_role_permission.patch",
                 "Maestro flow task entity autocomplete patch": "patches/drupal/maestro/maestro_entity_autocomplete.patch"
+            },
+            "os2forms/os2forms": {
+                "Hide additional os2forms webform settings page": "patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff"
             }
         },
         "patches-ignore": {

--- a/patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff
+++ b/patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff
@@ -1,0 +1,10 @@
+diff --git a/os2forms.routing.yml b/os2forms.routing.yml
+index 8f55e52..8b4074e 100644
+--- a/os2forms.routing.yml
++++ b/os2forms.routing.yml
+@@ -11,4 +11,5 @@ os2forms.entity.webform.settings_form:
+     _entity_form: webform.os2forms_settings
+     _title_callback: '\Drupal\webform\Controller\WebformEntityController::title'
+   requirements:
++    _access: 'FALSE'
+     _entity_access: 'webform.update'


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/1237

* Hides additional os2forms webform settings page

The additional settings page is redundant as all settings within is contained in the general settings page. Furthermore, saving settings on this page may result in unintended setting changes.


Composer hash value cannot be updated due to a removal of tag in `tecnickcom/tcpdf`. See https://github.com/itk-dev/os2forms_selvbetjening/pull/303