### PR TITLE
Fix site install

### DIFF
--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -25,6 +25,7 @@ module:
   contextual: 0
   ctools: 0
   datetime: 0
+  dblog: 0
   diff: 0
   drupal_psr6_cache: 0
   dynamic_entity_reference: 0


### PR DESCRIPTION
Configuration _ultimate_cron.job.dblog_cron_ depends on the _Database Logging_ module that will not be installed after import.