### PR TITLE
1237: Added patch hiding additional os2forms settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Fjernede ekstra OS2Forms indstillingsfaneblad på formularer.
+
 ## [2.7.11] 2024-05-02
 
 * Opdaterede Maestro flows user autocomplete til at søge på navn.

--- a/composer.json
+++ b/composer.json
@@ -153,6 +153,9 @@
             },
             "drupal/log_stdout": {
                 "Severities should not be translated in logs - 3432622": "https://git.drupalcode.org/project/log_stdout/-/merge_requests/8.diff"
+            },
+            "os2forms/os2forms": {
+                "Hide additional os2forms webform settings page": "patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff"
             }
         },
         "patches-ignore": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccf5ad5bc62db1213aaae89f467e26d3",
+    "content-hash": "b69808d9b0648aa15e24011e37d0259b",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff
+++ b/patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff
@@ -1,0 +1,10 @@
+diff --git a/os2forms.routing.yml b/os2forms.routing.yml
+index 8f55e52..8b4074e 100644
+--- a/os2forms.routing.yml
++++ b/os2forms.routing.yml
+@@ -11,4 +11,5 @@ os2forms.entity.webform.settings_form:
+     _entity_form: webform.os2forms_settings
+     _title_callback: '\Drupal\webform\Controller\WebformEntityController::title'
+   requirements:
++    _access: 'FALSE'
+     _entity_access: 'webform.update'


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/1237

* Hides additional os2forms webform settings page

The additional settings page is redundant as all settings within is contained in the general settings page. Furthermore, saving settings on this page may result in unintended setting changes.