### PR TITLE
1303: Add missing os2forms_fasit queue config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede `os2forms_fasit` kø konfiguration.
+
 ## [2.7.11] 2024-05-02
 
 * Opdaterede Maestro flows user autocomplete til at søge på navn.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
-* Tilføjede `os2forms_fasit` kø konfiguration.
+* Tilføjede `os2forms_fasit`-kø-konfiguration.
 
 ## [2.7.11] 2024-05-02
 

--- a/config/sync/advancedqueue.advancedqueue_queue.fasit_queue.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.fasit_queue.yml
@@ -1,0 +1,16 @@
+uuid: 4c32545f-717b-478e-9ddc-b35992dc7b69
+langcode: da
+status: true
+dependencies: {  }
+id: fasit_queue
+label: 'Fasit Queue'
+backend: database
+backend_configuration:
+  lease_time: 300
+processor: daemon
+processing_time: 280
+threshold:
+  type: 0
+  limit: 0
+  state: all
+locked: false


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/1303

* Adds missing `os2forms_fasit` queue config.