### PR TITLE
2077: Force webform_revision to be null on submissions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,8 @@
             "drupal/config_entity_revisions":  {
                 "Add check to see if entity revision actually exists(https://www.drupal.org/project/config_entity_revisions/issues/3277467)": "https://www.drupal.org/files/issues/2022-04-27/add-check-to-see-if-entity-revision-actually-exists-3277467-3.patch",
                 "https://www.drupal.org/project/config_entity_revisions/issues/3260602": "https://www.drupal.org/files/issues/2022-03-15/content_entity_revisions-3260602-07.patch",
-                "webform_revisions_install called twice during site:install --existing-config": "patches/drupal/config_entity_revisions/webform_revisions.install.patch"
+                "webform_revisions_install called twice during site:install --existing-config": "patches/drupal/config_entity_revisions/webform_revisions.install.patch",
+                "Always set webform_revision to NULL on webform submissions": "patches/drupal/config_entity_revisions/WebformRevisionController.patch"
             },
             "drupal/permissions_by_term": {
                 "Change check for node form": "patches/drupal/permissions_by_term/changeNodeCheck.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "07708cd52b7439c020935b1474268e09",
+    "content-hash": "4eafaaacc35211f07fe011b47db6388c",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/drupal/config_entity_revisions/WebformRevisionController.patch
+++ b/patches/drupal/config_entity_revisions/WebformRevisionController.patch
@@ -1,0 +1,12 @@
+diff --git a/modules/webform_revisions/src/Controller/WebformRevisionsController.php b/modules/webform_revisions/src/Controller/WebformRevisionsController.php
+index f7dc1ef..273716d 100644
+--- a/modules/webform_revisions/src/Controller/WebformRevisionsController.php
++++ b/modules/webform_revisions/src/Controller/WebformRevisionsController.php
+@@ -90,6 +90,6 @@ class WebformRevisionsController extends ConfigEntityRevisionsControllerBase imp
+     /* @var $webform \Drupal\webform_revisions\Entity\WebformRevisions */
+     $webform = $entity->getWebform();
+ 
+-    $entity->set('webform_revision', $webform->getRevisionID());
++    $entity->set('webform_revision', NULL);
+   }
+ }

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.install
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.install
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Install file for OS2Forms Selvbetjening module.
+ */
+
+use Drupal\os2forms_selvbetjening\Helper\InstallHelper;
+
+/**
+ * Implements hook_update_N().
+ *
+ * Set webform_revision to NULL on all existing submissions.
+ *
+ * This is done to avoid various issues we have encountered with
+ * webform revisions e.g. stray submissions and repeated identical joins
+ * during load of submissions.
+ * Future submissions is handled by a patch ensuring it is always set to NULL,
+ * @see patches/drupal/config_entity_revisions/WebformRevisionController.patch.
+ */
+function os2forms_selvbetjening_update_9501() {
+  Drupal::service(InstallHelper::class)->nullifyExistingWebformSubmissionRevisions($form, $form_state, $form_id);
+}

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
@@ -18,3 +18,8 @@ services:
       - '@router.admin_context'
     tags:
       - { name: 'event_subscriber' }
+
+  Drupal\os2forms_selvbetjening\Helper\InstallHelper:
+    arguments:
+      - '@module_handler'
+      - '@database'

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/InstallHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/InstallHelper.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\os2forms_selvbetjening\Helper;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\os2forms_selvbetjening\Exception\SelvbetjeningException;
+
+/**
+ * Helper for install.
+ */
+class InstallHelper {
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $moduleInstaller
+   *   Module handler.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The database connection.
+   */
+  public function __construct(
+    private readonly ModuleHandlerInterface $moduleInstaller,
+    private readonly Connection $connection
+  ) {
+  }
+
+  /**
+   * Nullify webform revision on existing webform submissions.
+   *
+   * @throws \Drupal\os2forms_selvbetjening\Exception\SelvbetjeningException
+   */
+  public function nullifyExistingWebformSubmissionRevisions() {
+    if (!$this->moduleInstaller->moduleExists('webform_revisions')) {
+      return;
+    }
+
+    // Loop through all submissions setting webform_revision to null.
+    try {
+      $this->connection->update('webform_submission')
+        ->fields([
+          'webform_revision' => NULL,
+        ])
+        ->execute();
+    }
+    catch (\Exception $e) {
+      throw new SelvbetjeningException('Unable to update webform revisions on submissions.', $e->getCode(), $e);
+    }
+  }
+
+}


### PR DESCRIPTION
https://leantime.itkdev.dk/dashboard/home#/tickets/showTicket/2077

* Adds patch ensuring future submissions always have `webform_revision` `NULL`
* Adds update hook to `os2forms_selvbetjening` updating all submissions to have `webform_revision` `NULL`