### PR TITLE
2161: Added patch making https default on CKEditor 5 links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* CKEditor 5 link standard `https` protocol.
+
 ## [2.8.1] 2024-08-26
 
 * Oprydning af konfiguration.

--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,8 @@
                 "Set to support. Checkbox condition fixes": "https://raw.githubusercontent.com/OS2Forms/os2forms8/master/patches/setto-and-checkboxes-condition-fix-onlyD7.patch"
             },
             "drupal/core": {
-                "Allow site install with profile containing hook_install (https://www.drupal.org/project/drupal/issues/2982052)": "https://www.drupal.org/files/issues/2022-05-19/2982052-80.patch"
+                "Allow site install with profile containing hook_install (https://www.drupal.org/project/drupal/issues/2982052)": "https://www.drupal.org/files/issues/2022-05-19/2982052-80.patch",
+                "CKEditor 5 link default protocol https": "patches/drupal/core/ckeditor_5_link_default_https.patch"
             },
             "drupal/openid_connect": {
                 "Revoking group access does not reflect on applied roles (https://www.drupal.org/project/openid_connect/issues/3224128)": "https://git.drupalcode.org/project/openid_connect/-/merge_requests/31.diff"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3736315ed29e65c0a492c205da805d6",
+    "content-hash": "770524fd887e3aa36cd20fc22a7c0e9e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1963,7 +1963,7 @@
                     "homepage": "https://www.drupal.org/user/1305230"
                 },
                 {
-                    "name": "Dave Reid",
+                    "name": "dave reid",
                     "homepage": "https://www.drupal.org/user/53892"
                 },
                 {

--- a/patches/drupal/core/ckeditor_5_link_default_https.patch
+++ b/patches/drupal/core/ckeditor_5_link_default_https.patch
@@ -1,0 +1,15 @@
+diff --git a/core/modules/ckeditor5/ckeditor5.ckeditor5.yml b/core/modules/ckeditor5/ckeditor5.ckeditor5.yml
+index 0a19bdca90..140412e714 100644
+--- a/core/modules/ckeditor5/ckeditor5.ckeditor5.yml
++++ b/core/modules/ckeditor5/ckeditor5.ckeditor5.yml
+@@ -328,6 +328,10 @@ ckeditor5_link:
+   ckeditor5:
+     plugins:
+       - link.Link
++    config:
++      link:
++        # @see https://ckeditor.com/docs/ckeditor5/latest/features/link.html#adding-default-link-protocol-to-external-links
++        defaultProtocol: 'https://'
+   drupal:
+     label: Link
+     library: core/ckeditor5.link


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/2161

* Sets `https://` as default protocol

If any other protocol is detected (which hopefully never happens) it will not be overwritten. It is also still possible add links relative to site url, `{site_url}/hest` by using `/hest`

This is purely done to help webform editors and is something that has been added to Drupal 11.x (cf. https://www.drupal.org/project/drupal/issues/2893568)
