### PR TITLE
Updated os2forms organisation version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [2.8.2] XXX
 
+* Opdaterede [OS2Forms Organisation](https://github.com/itk-dev/os2forms_organisation) version.
 * Tilføjede signatur-element patches.
 * CKEditor 5 link standard `https` protocol.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [2.8.2] XXX
 
-* Opdaterede [OS2Forms Organisation](https://github.com/itk-dev/os2forms_organisation) version.
+* Opdaterede [OS2Forms Organisation](https://github.com/itk-dev/os2forms_organisation)
+  version.
 * Tilføjede signatur-element patches.
 * CKEditor 5 link standard `https` protocol.
 

--- a/composer.lock
+++ b/composer.lock
@@ -10432,16 +10432,16 @@
         },
         {
             "name": "os2forms/os2forms_organisation",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itk-dev/os2forms_organisation.git",
-                "reference": "052f29b636e9fcd9d240ee378a995e6afcd25ca5"
+                "reference": "465d64a6d1f9e79f409d8d400da2e5e59b29ec89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/itk-dev/os2forms_organisation/zipball/052f29b636e9fcd9d240ee378a995e6afcd25ca5",
-                "reference": "052f29b636e9fcd9d240ee378a995e6afcd25ca5",
+                "url": "https://api.github.com/repos/itk-dev/os2forms_organisation/zipball/465d64a6d1f9e79f409d8d400da2e5e59b29ec89",
+                "reference": "465d64a6d1f9e79f409d8d400da2e5e59b29ec89",
                 "shasum": ""
             },
             "require": {
@@ -10471,9 +10471,9 @@
             "description": "OS2Forms organisation",
             "support": {
                 "issues": "https://github.com/itk-dev/os2forms_organisation/issues",
-                "source": "https://github.com/itk-dev/os2forms_organisation/tree/2.0.1"
+                "source": "https://github.com/itk-dev/os2forms_organisation/tree/2.0.2"
             },
-            "time": "2024-01-23T12:32:32+00:00"
+            "time": "2024-06-25T07:22:53+00:00"
         },
         {
             "name": "os2forms/os2forms_rest_api",


### PR DESCRIPTION
* Upgrade to latest `os2forms/os2forms_organisation` https://github.com/itk-dev/os2forms_organisation/releases/tag/2.0.2