### PR TITLE
2899: Added Maestro notificaton filter format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 * Tilføjede "Begrænset HTML (Maestro)"-tekstformat.
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Opdaterede docker-compose node setup.
-* Opdaterede [Azure Key Vault](https://github.com/itk-dev/AzureKeyVaultPhp) for at rette "Cannot fetch SAML token"-fejl.
+* Opdaterede [Azure Key Vault](https://github.com/itk-dev/AzureKeyVaultPhp) for
+  at rette "Cannot fetch SAML token"-fejl.
 
 ## [2.8.3] 2024-09-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede "Begrænset HTML (Maestro)"-tekstformat.
 * Tilføjede mulighed for csv eksport af alle formular konfigurationer.
 * Opdaterede docker-compose node setup.
 * Opdaterede [Azure Key Vault](https://github.com/itk-dev/AzureKeyVaultPhp) for at rette "Cannot fetch SAML token"-fejl.

--- a/config/sync/filter.format.maestro_notification.yml
+++ b/config/sync/filter.format.maestro_notification.yml
@@ -1,0 +1,30 @@
+uuid: fef9fa1b-32cc-4771-aa08-1afb324def24
+langcode: da
+status: true
+dependencies: {  }
+name: 'Maestro-notifikation'
+format: maestro_notification
+weight: 0
+filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: false
+    weight: -10
+    settings:
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id>'
+      filter_html_help: true
+      filter_html_nofollow: false

--- a/config/sync/user.role.flow_designer.yml
+++ b/config/sync/user.role.flow_designer.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.full_html
     - filter.format.restricted_html
+    - filter.format.maestro_notification
     - filter.format.webform
     - node.type.webform
     - workflows.workflow.udgivelse_af_forlob_og_webformularer
@@ -83,6 +84,7 @@ permissions:
   - 'use advanced search'
   - 'use text format full_html'
   - 'use text format restricted_html'
+  - 'use text format maestro_notification'
   - 'use text format webform'
   - 'use udgivelse_af_forlob_og_webformularer transition create_new_draft'
   - 'use udgivelse_af_forlob_og_webformularer transition publish'

--- a/config/sync/user.role.sagsbehandler.yml
+++ b/config/sync/user.role.sagsbehandler.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - filter.format.full_html
     - filter.format.restricted_html
+    - filter.format.maestro_notification
     - filter.format.webform
   module:
     - block_content
@@ -68,6 +69,7 @@ permissions:
   - 'use advanced search'
   - 'use text format full_html'
   - 'use text format restricted_html'
+  - 'use text format maestro_notification'
   - 'use text format webform'
   - 'view any unpublished content'
   - 'view any webform submission'


### PR DESCRIPTION
https://leantime.itkdev.dk/TimeTable/TimeTable?tab=ticketdetails#/tickets/showTicket/2899

`UrlHelper::stripDangerousProtocols` strips all tokens at start of `href` attribute value, i.e. `<a href="[maestro:task-url]">…</a>`  becomes `<a href="task-url]">…</a>`, when filtering HTML. Therefore, we add a custom text format, Maestro-notifikation, that does _not_ filter HTML

See https://www.drupal.org/project/drupal/issues/2372127 for details on the issue.