### PR TITLE
3168: webform ckeditor toolbar fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
+* Opdaterede ckeditor konfiguration til
+  altid at vise værktøjslinje.
+
 ## [Under udvikling]
 
 ## [3.1.1] 3024-11-25

--- a/config/sync/editor.editor.webform.yml
+++ b/config/sync/editor.editor.webform.yml
@@ -32,6 +32,7 @@ settings:
       - blockQuote
       - '|'
       - sourceEditing
+      - '-'
   plugins:
     ckeditor5_heading:
       enabled_headings:


### PR DESCRIPTION
[3168](https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/3168)

Shows all icons in the ckeditor instead of hiding them in a dropdown.