### PR TITLE
Upgraded os2forms core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 * Opdaterede ckeditor konfiguration til
   altid at vise værktøjslinje.
 * Opdaterede [OS2Web Datalookup](https://github.com/OS2web/os2web_datalookup/) version.
+* Opdaterede til OS2Forms 3.19.0
+  * Fasit handler
+  * Audit logging af digital post
+  * Audit logging af nemid felter
+* Fjerende direkte requirement af `os2forms/os2forms_fasit`.
+  * Denne kommer nu gennem OS2Forms core.
 
 ## [3.1.1] 3024-11-25
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "itk-dev/os2forms_user_field_lookup": "^1.1",
         "itk-dev/web_accessibility_statement": "^1.1",
         "os2forms/os2forms": "^3.16",
-        "os2forms/os2forms_fasit": "^1.1",
         "os2forms/os2forms_forloeb_profile": "dev-f/d10_readiness",
         "os2forms/os2forms_get_organized": "^1.2",
         "os2forms/os2forms_organisation": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "139c37b03150bcfefadd79f565887405",
+    "content-hash": "ae0543ec41a234c8db3688a2851473b5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -9252,16 +9252,16 @@
         },
         {
             "name": "os2forms/os2forms",
-            "version": "3.17.0",
+            "version": "3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OS2Forms/os2forms.git",
-                "reference": "a79a9b91e981de87114caa292a654f9cc1331a71"
+                "reference": "b0c0e73ab8e68dcedfa6d3f4c42c91a19dd6d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OS2Forms/os2forms/zipball/a79a9b91e981de87114caa292a654f9cc1331a71",
-                "reference": "a79a9b91e981de87114caa292a654f9cc1331a71",
+                "url": "https://api.github.com/repos/OS2Forms/os2forms/zipball/b0c0e73ab8e68dcedfa6d3f4c42c91a19dd6d5f8",
+                "reference": "b0c0e73ab8e68dcedfa6d3f4c42c91a19dd6d5f8",
                 "shasum": ""
             },
             "require": {
@@ -9340,27 +9340,25 @@
             },
             "type": "drupal-module",
             "extra": {
-                "composer-exit-on-patch-failure": false,
-                "enable-patching": true,
                 "patches": {
+                    "drupal/webform": {
+                        "Webform computed element post save alter": "https://www.drupal.org/files/issues/2024-06-25/webform_computed_post_save_field_alter.patch",
+                        "Unlock possibility of using Entity print module export to Word": "https://www.drupal.org/files/issues/2020-02-29/3096552-6.patch"
+                    },
                     "drupal/entity_print": {
                         "2733781 - Add Export to Word Support": "https://www.drupal.org/files/issues/2019-11-22/2733781-47.patch"
-                    },
-                    "drupal/webform": {
-                        "Unlock possibility of using Entity print module export to Word": "https://www.drupal.org/files/issues/2020-02-29/3096552-6.patch",
-                        "Webform computed element post save alter": "https://www.drupal.org/files/issues/2024-06-25/webform_computed_post_save_field_alter.patch"
-                    },
-                    "drupal/coc_forms_auto_export": {
-                        "3240592 - Problem with phpseclib requirement in 2.x (https://www.drupal.org/project/coc_forms_auto_export/issues/3240592)": "https://www.drupal.org/files/issues/2021-10-04/requirement-namespace-3240592-1.patch",
-                        "3286562 - Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2022-06-15/coc_forms_auto_export.2.0.x-dev.rector.patch",
-                        "3259009 - PHP Warnings/Notices on Download Page": "https://git.drupalcode.org/project/coc_forms_auto_export/-/merge_requests/1.diff"
-                    },
-                    "drupal/webform_node_element": {
-                        "3290637 - Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2023-05-12/webform_node_element_d10-3290637-11.patch"
                     },
                     "drupal/webform_encrypt": {
                         "Ensure data is base64 encoded (https://www.drupal.org/project/webform_encrypt/issues/3399414)": "https://git.drupalcode.org/project/webform_encrypt/-/merge_requests/4.patch",
                         "PHP Warning if unserialize fails (https://www.drupal.org/project/webform_encrypt/issues/3292305)": "https://www.drupal.org/files/issues/2022-06-23/unserialize-php-notice.patch"
+                    },
+                    "drupal/webform_node_element": {
+                        "3290637 - Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2023-05-12/webform_node_element_d10-3290637-11.patch"
+                    },
+                    "drupal/coc_forms_auto_export": {
+                        "3259009 - PHP Warnings/Notices on Download Page": "https://git.drupalcode.org/project/coc_forms_auto_export/-/merge_requests/1.diff",
+                        "3286562 - Automated Drupal 10 compatibility fixes": "https://www.drupal.org/files/issues/2022-06-15/coc_forms_auto_export.2.0.x-dev.rector.patch",
+                        "3240592 - Problem with phpseclib requirement in 2.x (https://www.drupal.org/project/coc_forms_auto_export/issues/3240592)": "https://www.drupal.org/files/issues/2021-10-04/requirement-namespace-3240592-1.patch"
                     }
                 },
                 "drupal-lenient": {
@@ -9368,7 +9366,9 @@
                         "drupal/coc_forms_auto_export",
                         "drupal/webform_node_element"
                     ]
-                }
+                },
+                "enable-patching": true,
+                "composer-exit-on-patch-failure": false
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -9377,54 +9377,9 @@
             "description": "Drupal 8 OS2Form module provides advanced webform functionality for Danish Municipalities",
             "support": {
                 "issues": "https://github.com/OS2Forms/os2forms/issues",
-                "source": "https://github.com/OS2Forms/os2forms/tree/3.17.0"
+                "source": "https://github.com/OS2Forms/os2forms/tree/3.19.0"
             },
-            "time": "2024-11-21T10:25:47+00:00"
-        },
-        {
-            "name": "os2forms/os2forms_fasit",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/itk-dev/os2forms_fasit.git",
-                "reference": "6c0fdd560230e92d0be1f88bdbdfefa329f762c5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/itk-dev/os2forms_fasit/zipball/6c0fdd560230e92d0be1f88bdbdfefa329f762c5",
-                "reference": "6c0fdd560230e92d0be1f88bdbdfefa329f762c5",
-                "shasum": ""
-            },
-            "require": {
-                "drupal/advancedqueue": "^1.0",
-                "drupal/webform": "^6.1",
-                "ext-dom": "*",
-                "os2forms/os2forms": "^3.16",
-                "php": "^8.3",
-                "symfony/options-resolver": "^5.4 || ^6.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-                "drupal/coder": "^8.3",
-                "mglaman/drupal-check": "^1.4"
-            },
-            "type": "drupal-module",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jeppe Kuhlmann Andersen",
-                    "email": "jekua@aarhus.dk"
-                }
-            ],
-            "description": "OS2Forms Fasit integration",
-            "support": {
-                "issues": "https://github.com/itk-dev/os2forms_fasit/issues",
-                "source": "https://github.com/itk-dev/os2forms_fasit/tree/1.2.0"
-            },
-            "time": "2024-09-26T11:56:13+00:00"
+            "time": "2024-12-06T09:49:09+00:00"
         },
         {
             "name": "os2forms/os2forms_forloeb_profile",


### PR DESCRIPTION
Upgrades to `os2forms/os2forms` 3.19

* Removes `os2forms/os2forms_fasit` requirement
   * `os2forms_fasit` has been moved to core, since  3.18 (https://github.com/OS2Forms/os2forms/releases/tag/3.18.0)
* Introduces audit logging of
  *  Digital post
  * Nemid elements