### PR TITLE
#3210: Added patch fixing error regarding æøå in webform searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede patch der retter fejl angående æøå i webform søgning.
 * Tilføjede update site tjek til GitHub Actions.
 * Opdaterede
   [OS2Forms GetOrganized](https://github.com/OS2Forms/os2forms_get_organized) version.

--- a/composer.json
+++ b/composer.json
@@ -157,6 +157,9 @@
                 "Maestro task notification permission patch": "patches/drupal/maestro/maestro_task_select_notification_role_permission.patch",
                 "Maestro flow task entity autocomplete patch": "patches/drupal/maestro/maestro_entity_autocomplete.patch"
             },
+            "drupal/webform": {
+                "Fix issue with webform search containing æøå": "https://www.drupal.org/files/issues/2024-02-26/3415445-cant-load-non-english_0.patch"
+            },
             "os2forms/os2forms": {
                 "Hide additional os2forms webform settings page": "patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff"
             }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "033d1c22d7bcc6ad3982c0039249f9d9",
+    "content-hash": "a8ffa4407013e3112ed8b9e81a4fa76f",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
[3210](https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/3210)
- Added patch for issue regarding webform searches containing æøå