### PR TITLE
Purge succesful audit logging jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Automatisk sletning af vellykkede audit logging jobs.
+
 ## [3.2.1] 2024-12-19
 
 * Opdaterede `os2forms_rest_api`

--- a/config/sync/advancedqueue.advancedqueue_queue.os2web_audit.yml
+++ b/config/sync/advancedqueue.advancedqueue_queue.os2web_audit.yml
@@ -9,3 +9,8 @@ backend_configuration:
 processor: daemon
 processing_time: 90
 locked: false
+stop_when_empty: true
+threshold:
+  type: 2
+  limit: 7
+  state: success


### PR DESCRIPTION
* Purges successful advanced queue audit log jobs after 7 days. 

**Note:** Cleanup is done every time the queue is processed.

Before:

<img width="788" alt="Screenshot 2024-12-19 at 11 23 01" src="https://github.com/user-attachments/assets/f7851a49-db47-4e2d-9d0e-48e6f4fdb47a" />

After:
<img width="788" alt="Screenshot 2024-12-19 at 11 22 20" src="https://github.com/user-attachments/assets/0a1b8af4-bc51-4258-adb7-72a34de2dab1" />
