### PR TITLE
3088: Add phonenumber and only set if provided

### DIFF
--- a/web/modules/custom/os2forms_fbs_handler/src/Client/FBS.php
+++ b/web/modules/custom/os2forms_fbs_handler/src/Client/FBS.php
@@ -117,6 +117,12 @@ final class FBS {
       'name' => 'Unknown Name',
       'emailAddresses' => $patron->emailAddresses,
       'guardian' => $guardian->toArray(),
+      'phoneNumbers' => isset($patron->phoneNumber) && $patron->phoneNumber ? [
+        [
+          'receiveNotification' => TRUE,
+          'phoneNumber' => $patron->phoneNumber,
+        ],
+      ] : [],
     ];
 
     return $this->request($uri, $payload);
@@ -184,12 +190,12 @@ final class FBS {
         'emailAddresses' => $patron->emailAddresses,
         'guardianVisibility' => $patron->guardianVisibility,
         'receivePostalMail' => $patron->receiveEmail,
-        'phoneNumbers' => [
+        'phoneNumbers' => isset($patron->phoneNumber) && $patron->phoneNumber ? [
           [
             'receiveNotification' => TRUE,
             'phoneNumber' => $patron->phoneNumber,
           ],
-        ],
+        ] : [],
       ],
       'pincodeChange' => [
         'pincode' => $patron->pincode,

--- a/web/modules/custom/os2forms_fbs_handler/src/Client/Model/Patron.php
+++ b/web/modules/custom/os2forms_fbs_handler/src/Client/Model/Patron.php
@@ -15,7 +15,7 @@ final class Patron {
     public readonly ?bool $receiveSms = FALSE,
     public readonly ?bool $receivePostalMail = FALSE,
     public readonly ?array $notificationProtocols = NULL,
-    public readonly ?string $phoneNumber = NULL,
+
     public readonly ?array $onHold = NULL,
     public readonly ?string $preferredLanguage = NULL,
     public readonly ?bool $guardianVisibility = NULL,
@@ -27,6 +27,7 @@ final class Patron {
     public ?string $preferredPickupBranch = NULL,
     public ?string $personId = NULL,
     public ?string $pincode = NULL,
+    public ?string $phoneNumber = NULL,
   ) {
   }
 

--- a/web/modules/custom/os2forms_fbs_handler/src/Plugin/AdvancedQueue/JobType/FbsCreateUser.php
+++ b/web/modules/custom/os2forms_fbs_handler/src/Plugin/AdvancedQueue/JobType/FbsCreateUser.php
@@ -109,6 +109,9 @@ final class FbsCreateUser extends JobTypeBase implements ContainerFactoryPluginI
                 'receiveNotification' => TRUE,
               ],
             ];
+            if (isset($data['barn_tlf'])) {
+              $patron->phoneNumber = $data['barn_tlf'];
+            }
             $patron->receiveEmail = TRUE;
             $patron->pincode = $data['pinkode'];
 
@@ -129,6 +132,9 @@ final class FbsCreateUser extends JobTypeBase implements ContainerFactoryPluginI
           $patron->receiveEmail = TRUE;
           $patron->personId = $data['barn_cpr'];
           $patron->pincode = $data['pinkode'];
+          if (isset($data['barn_tlf'])) {
+            $patron->phoneNumber = $data['barn_tlf'];
+          }
 
           $fbs->createPatronWithGuardian($patron, $guardian);
         }

--- a/web/modules/custom/os2forms_fbs_handler/src/Plugin/WebformHandler/FbsWebformHandler.php
+++ b/web/modules/custom/os2forms_fbs_handler/src/Plugin/WebformHandler/FbsWebformHandler.php
@@ -175,6 +175,7 @@ final class FbsWebformHandler extends WebformHandlerBase {
       'afhentningssted',
       'barn_cpr',
       'barn_mail',
+      'barn_tlf',
       'cpr',
       'email',
       'navn',


### PR DESCRIPTION
- **Add conditional handling for phoneNumbers in create and update patron methods.**
- **Move phoneNumber from readonly properties to non-readonly properties.**
- **Assign phoneNumber to patron when barn_tlf is present in advanced queue job.**
- **Include barn_tlf field when processing webform submission.**
