### PR TITLE
3758: Increased memory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Øgede tilladt hukommelsesforbrug.
+
 ## [3.2.4] 2025-01-07
 
 * Opdaterede `os2forms` core modulet.

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -14,7 +14,7 @@ services:
       - organisation_api
     environment:
       - PHP_MAX_EXECUTION_TIME=30
-      - PHP_MEMORY_LIMIT=512M
+      - PHP_MEMORY_LIMIT=1024M
       - PHP_POST_MAX_SIZE=305M
       - PHP_UPLOAD_MAX_FILESIZE=300M
       - PHP_OPCACHE_VALIDATE_TIMESTAMPS=0


### PR DESCRIPTION
<https://leantime.itkdev.dk/#/tickets/showTicket/3758>

Increases memory limit due to 

> $ docker compose exec phpfpm vendor/bin/drush --uri=https://selvbetjening.aarhuskommune.dk/ advancedqueue:queue:process get_organized_queue -vvv
>  …
> PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 134217736 bytes) in /app/vendor/itk-dev/getorganized-api-client-php/src/Service/Documents.php on line 205
>  [warning] Drush command terminated abnormally. [13.39 sec, 444.24 MB]
