### PR TITLE
177: Added webform patch avoiding element container titles in emails …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede patch der undgår container titler i e-mails
+  når de ikke har underelementer.
+
 ## [3.2.5] 2025-02-11
 
 * Opdaterede `os2forms_payment`.

--- a/composer.json
+++ b/composer.json
@@ -158,7 +158,8 @@
                 "Maestro flow task entity autocomplete patch": "patches/drupal/maestro/maestro_entity_autocomplete.patch"
             },
             "drupal/webform": {
-                "Fix issue with webform search containing æøå": "https://www.drupal.org/files/issues/2024-02-26/3415445-cant-load-non-english_0.patch"
+                "Fix issue with webform search containing æøå": "https://www.drupal.org/files/issues/2024-02-26/3415445-cant-load-non-english_0.patch",
+                "Email handler shows fieldset and section titles despite all children fields etc are excluded (https://www.drupal.org/project/webform/issues/3482544)": "patches/drupal/webform/email_handler_titles_despite_exluded_element.patch"
             },
             "os2forms/os2forms": {
                 "Hide additional os2forms webform settings page": "patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8ffa4407013e3112ed8b9e81a4fa76f",
+    "content-hash": "fb2b593dfdc10c6cd50591e37c33c251",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/drupal/webform/email_handler_titles_despite_exluded_element.patch
+++ b/patches/drupal/webform/email_handler_titles_despite_exluded_element.patch
@@ -1,0 +1,57 @@
+diff --git a/src/Plugin/WebformElement/ContainerBase.php b/src/Plugin/WebformElement/ContainerBase.php
+index a3afd9abb167e252932690404e6a145bdd5b8901..0eb3d4f4262bc8b10f7fcced486c4d9c2cddf4ed 100644
+--- a/src/Plugin/WebformElement/ContainerBase.php
++++ b/src/Plugin/WebformElement/ContainerBase.php
+@@ -120,6 +120,17 @@ abstract class ContainerBase extends WebformElementBase {
+     /** @var \Drupal\webform\WebformSubmissionViewBuilderInterface $view_builder */
+     $view_builder = $this->entityTypeManager->getViewBuilder('webform_submission');
+     $children = $view_builder->buildElements($element, $webform_submission, $options, 'html');
++
++    // Remove any children that are listed as excluded elements.
++    if (!empty($children)) {
++      foreach ($options['excluded_elements'] ?? [] as $excluded_element) {
++        if (isset($children[$excluded_element])) {
++          unset($children[$excluded_element]);
++        }
++      }
++    }
++
++    // No need to format the item if it has no children.
+     if (empty($children)) {
+       return [];
+     }
+@@ -191,6 +202,17 @@ abstract class ContainerBase extends WebformElementBase {
+     /** @var \Drupal\webform\WebformSubmissionViewBuilderInterface $view_builder */
+     $view_builder = $this->entityTypeManager->getViewBuilder('webform_submission');
+     $children = $view_builder->buildElements($element, $webform_submission, $options, 'text');
++
++    // Remove any children that are listed as excluded elements.
++    if (!empty($children)) {
++      foreach ($options['excluded_elements'] ?? [] as $excluded_element) {
++        if (isset($children[$excluded_element])) {
++          unset($children[$excluded_element]);
++        }
++      }
++    }
++
++    // No need to format the item if it has no children.
+     if (empty($children)) {
+       return [];
+     }
+@@ -222,6 +244,15 @@ abstract class ContainerBase extends WebformElementBase {
+       /** @var \Drupal\webform\WebformSubmissionViewBuilderInterface $view_builder */
+       $view_builder = $this->entityTypeManager->getViewBuilder('webform_submission');
+       $context['children'] = $view_builder->buildElements($element, $webform_submission, $options, $name);
++
++      // Remove any children that are listed as excluded elements.
++      if (!empty($context['children'])) {
++        foreach ($options['excluded_elements'] ?? [] as $excluded_element) {
++          if (isset($context['children'][$excluded_element])) {
++            unset($context['children'][$excluded_element]);
++          }
++        }
++      }
+     }
+ 
+     return parent::formatCustomItem($type, $element, $webform_submission, $options, $context);
+


### PR DESCRIPTION
…when no subelements are included

https://leantime.itkdev.dk/#/tickets/showTicket/3802

* Adds patch for https://www.drupal.org/project/webform/issues/3482544
  * The applied patch is a diff from the relevant [MR](https://git.drupalcode.org/project/webform/-/merge_requests/533)