### PR TITLE
3915: Disabled webform ajax options for regular users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 * Tilføjede styling af tabel elementer i webform udsendte e-mails.
 * Tilføjede ekstra tjek i OS2Forms email handler.
 * Opdaterede `os2web_audit` modulet.
+* Deaktiverede formular ajax muligheden.
 
 ## [3.2.6] 2025-02-20
 

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -38,9 +38,14 @@ class FormHelper {
 
     $webform_category_description = $this->t('Externally: Citizen. Internally: Employees');
 
-    // Add description to category choice in Webform Settings.
+    // Webform general settings form.
     if ('webform_settings_form' === $form_id) {
+      // Add description to category choice in Webform Settings.
       $form['general_settings']['category']['#description'] = $webform_category_description;
+      // Disable access to ajax settings for non administrator users.
+      if (!in_array('administrator', $this->account->getRoles())) {
+        $form['ajax_settings']['#disabled'] = TRUE;
+      }
     }
 
     // Add description to category choice when adding new Webform.


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/3915

* Disables the ajax option on webform general settings for non administrators

> [!NOTE]  
Webforms with this already enabled will need to be updated, hence the option remains for administrators. See the specific webforms (3) on the leantime ticket.