### PR TITLE
Disable login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Deaktiverede login-formularen.
+
 * [3.2.9] 2025-03-12
 
 * Opdaterede `os2web_audit` modulet.

--- a/config/sync/openid_connect.settings.yml
+++ b/config/sync/openid_connect.settings.yml
@@ -5,7 +5,7 @@ always_save_userinfo: true
 connect_existing_users: true
 override_registration_settings: true
 end_session_enabled: true
-user_login_display: above
+user_login_display: replace
 redirect_login: ''
 redirect_logout: ''
 userinfo_mappings:

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
@@ -18,3 +18,7 @@ services:
       - '@router.admin_context'
     tags:
       - { name: 'event_subscriber' }
+
+  Drupal\os2forms_selvbetjening\Routing\RouteSubscriber:
+    tags:
+      - { name: 'event_subscriber' }

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -3,6 +3,8 @@
 namespace Drupal\os2forms_selvbetjening\Helper;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -78,6 +80,25 @@ class FormHelper {
         }
       }
     }
+
+    // Important: We must check the actual form ID on the form here; the
+    // 'user_login_form' may have been replaced with 'openid_connect_login_form'
+    // in openid_connect_form_user_login_form_alter (which see for details).
+    if ('user_login_form' === $form['#form_id']) {
+      // Remove all children and select stuff from login form.
+      $keysToUnset = [
+        ...Element::children($form),
+        '#validate',
+        '#submit',
+      ];
+      foreach ($keysToUnset as $key) {
+        unset($form[$key]);
+      }
+      $form['message'] = [
+        'message' => Link::createFromRoute($this->t('Login form has been disabled'), 'user.login')->toRenderable(),
+      ];
+    }
+
   }
 
 }

--- a/web/modules/custom/os2forms_selvbetjening/src/Routing/RouteSubscriber.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Routing/RouteSubscriber.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\os2forms_selvbetjening\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Route subscriber used to disable all login routes.
+ *
+ * @see https://drupal.stackexchange.com/a/272234
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Deny access to unwanted routes.
+    $disallowedRouteNames = [
+      'user.register',
+      'user.pass',
+    ];
+    foreach ($disallowedRouteNames as $name) {
+      if ($route = $collection->get($name)) {
+        $route->setRequirement('_access', 'FALSE');
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
<https://leantime.itkdev.dk/TimeTable/TimeTable?showTicketModal=4075#/tickets/showTicket/4075>

Disables login form in three steps to allow only login via OIDC:

First, we tell the OpenID Connect module to “Replace” the login form (https://github.com/itk-dev/os2forms_selvbetjening/pull/403/commits/74088c46ef0ea4010059e17372578ae341e37238):

Before:
![Screenshot 2025-03-20 at 12 18 28](https://github.com/user-attachments/assets/28db7e01-b91b-48fe-acb2-8beec4306c44)

After:
![Screenshot 2025-03-20 at 12 18 53](https://github.com/user-attachments/assets/d1b0c115-67bb-44a7-8d88-14c323b45f81)

Then we disable some login routes (https://github.com/itk-dev/os2forms_selvbetjening/pull/403/commits/704c39a861d568d769dc570aea95642646c503b8):

![Screenshot 2025-03-20 at 12 19 38](https://github.com/user-attachments/assets/60a8b5a5-46d7-45e3-9d04-344f85bc0803)

But the login form can still be summoned by adding `showcore` to the URL:

![Screenshot 2025-03-20 at 12 20 10](https://github.com/user-attachments/assets/38b3e7f1-3562-4c6c-ba9e-fefee9049d09)

so, finally, we disarm the login form (https://github.com/itk-dev/os2forms_selvbetjening/pull/403/commits/052b7a8de94941c18076d3cb33c251ab7fb707ad):

![Screenshot 2025-03-20 at 12 20 17](https://github.com/user-attachments/assets/724cf9c1-0aac-46c1-a636-899cbf2ab741)

And then, at the very end, we [update the changelog](https://github.com/itk-dev/os2forms_selvbetjening/pull/403/commits/c75ba0184764c50a98708aeec602ea002a034144).
