### PR TITLE
4239: Maestro bycontentfunction function validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede apostrof-regel til kodestandarder [PR-414](https://github.com/itk-dev/os2forms_selvbetjening/pull/414)
 * Tilføjede maestro bycontentfunction validation [PR-413](https://github.com/itk-dev/os2forms_selvbetjening/pull/413).
 
 ## [4.1.0] 2025-04-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede maestro bycontentfunction validation [PR-413](https://github.com/itk-dev/os2forms_selvbetjening/pull/413).
+
 ## [4.1.0] 2025-04-08
 
 * Ændrede PDF tabel visning [PR-404](https://github.com/itk-dev/os2forms_selvbetjening/pull/404)

--- a/config/sync/maestro.settings.yml
+++ b/config/sync/maestro.settings.yml
@@ -1,5 +1,5 @@
 maestro_send_notifications: 1
-maestro_orchestrator_task_console: 1
+maestro_orchestrator_task_console: 0
 maestro_redirect_location: /taskconsole
 maestro_orchestrator_token: AvfWr5bXdQcMpGTw4NHCMdjY44JXC8w0WOJUnq5s2zA3jh45TRHhCJfxcob0AqS
 maestro_orchestrator_lock_execution_time: '30'

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,4 +21,5 @@
   </rule>
 
   <rule ref="DrupalPractice"/>
+  <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
 </ruleset>

--- a/web/modules/custom/os2forms_email_handler/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
+++ b/web/modules/custom/os2forms_email_handler/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
@@ -214,7 +214,7 @@ class OS2FormsEmailWebformHandler extends EmailWebformHandler implements Contain
     $units = ['KB', 'MB', 'GB'];
 
     // Get number of units and units from threshold.
-    preg_match("/(?<num>\d+)(?<units>kb|mb|gb)$/i", $threshold, $matches);
+    preg_match('/(?<num>\d+)(?<units>kb|mb|gb)$/i', $threshold, $matches);
 
     $size = (int) $matches['num'];
     $unit = strtoupper($matches['units']);
@@ -272,7 +272,7 @@ class OS2FormsEmailWebformHandler extends EmailWebformHandler implements Contain
         $notificationMessage['subject'] = $this->t('File size submission warning');
 
         $notificationMessage['body'] = $this->t(
-          "<p>Dear @name</p><p>Submission @submission attempted sending an email with a large total file size of attachments surpassing @threshold for handler @handler (@handler_id) on form @form (@form_id).</p>", [
+          '<p>Dear @name</p><p>Submission @submission attempted sending an email with a large total file size of attachments surpassing @threshold for handler @handler (@handler_id) on form @form (@form_id).</p>', [
             '@name' => $emailAddress,
             '@submission' => $context['link'],
             '@handler' => $context['@handler'],

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
@@ -1,4 +1,7 @@
 services:
+  logger.channel.os2forms_selvbetjening:
+    parent: logger.channel_base
+    arguments: [ 'os2forms_selvbetjening' ]
 
   Drupal\os2forms_selvbetjening\Helper\WebformConfigurationExporter:
     arguments:
@@ -8,7 +11,7 @@ services:
   Drupal\os2forms_selvbetjening\Helper\FormHelper:
     arguments:
       - '@current_user'
-      - '@logger.channel.php'
+      - '@logger.channel.os2forms_selvbetjening'
 
   Drupal\Drupal\os2forms_selvbetjening\Form\SettingsForm:
     arguments:

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
@@ -8,6 +8,7 @@ services:
   Drupal\os2forms_selvbetjening\Helper\FormHelper:
     arguments:
       - '@current_user'
+      - '@logger.channel.default'
 
   Drupal\Drupal\os2forms_selvbetjening\Form\SettingsForm:
     arguments:

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
@@ -8,7 +8,7 @@ services:
   Drupal\os2forms_selvbetjening\Helper\FormHelper:
     arguments:
       - '@current_user'
-      - '@logger.channel.default'
+      - '@logger.channel.php'
 
   Drupal\Drupal\os2forms_selvbetjening\Form\SettingsForm:
     arguments:

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -153,7 +153,12 @@ class FormHelper {
             '%function_name' => $functionName,
           ])
         );
-        $this->logger->error($e->getMessage(), $e->getTrace());
+        $this->logger->error('Error reflecting function %function_name: %message', [
+          '%function_name' => $functionName,
+           %message' => $e->getMessage(),
+           // Add the full exception to the context for future reference.
+           'exception' => $e,
+        ]);
         return;
       }
 

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -141,7 +141,7 @@ class FormHelper {
         $form_state->setError($form['spv'], $this->t('Function %function_name does not exist', ['%function_name' => $functionName]));
         return;
       }
-      $this->logger->error('test hest error');
+      
       // Get the number of parameters for the defined function.
       try {
         $functionParamCount = (new \ReflectionFunction($functionName))->getNumberOfRequiredParameters();

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -107,7 +107,7 @@ final class FormHelper implements LoggerInterface {
     }
 
     if ('template_edit_task' === $form_id) {
-      $form['#validate'][] = [$this, "validateByContentFunction"];
+      $form['#validate'][] = [$this, 'validateByContentFunction'];
     }
   }
 
@@ -126,7 +126,7 @@ final class FormHelper implements LoggerInterface {
    *   The current state of the form.
    */
   public function validateByContentFunction(array &$form, FormStateInterface $form_state): void {
-    if ("bycontentfunction" === $form_state->getValue(['spv', 'method'])) {
+    if ('bycontentfunction' === $form_state->getValue(['spv', 'method'])) {
 
       // Get function name and parameters defined in the flow task.
       $value = $form_state->getValue(['spv', 'variable_value']);

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -9,8 +9,6 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
-use Drupal\maestro\Engine\MaestroEngine;
-use ReflectionFunction;
 
 /**
  * Form Helper class, for altering forms.
@@ -107,6 +105,23 @@ class FormHelper {
 
   }
 
+  /**
+   * Validates form input by checking a user-defined function.
+   *
+   * This method ensures that:
+   * - The specified function exists.
+   * - The number of provided parameters matches
+   * the defined function's requirements,
+   *   adjusted for additional parameters added during execution.
+   *
+   * @param array $form
+   *   The form structure.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @throws \ReflectionException
+   *   Function name specified cannot be reflected.
+   */
   public function validateByContentFunction(array &$form, FormStateInterface $form_state) {
     if ("bycontentfunction" === $form_state->getValue(['spv', 'method'])) {
 
@@ -130,7 +145,8 @@ class FormHelper {
       // Get the number of parameters for the defined function.
       $functionParamCount = (new \ReflectionFunction($functionName))->getNumberOfRequiredParameters();
 
-      // The maestro execute method always adds 2 parameters (queueID and processID) when handling the "bycontentfunction" case.
+      // The maestro execute method always adds 2 parameters
+      // (queueID and processID) when handling the "bycontentfunction" case.
       // @see MaestroSetProcessVariableTask::execute()
       $functionParamCount -= 2;
 
@@ -141,8 +157,19 @@ class FormHelper {
 
       // Check if the number of parameters matches.
       if ($paramCount !== $functionParamCount) {
-        $form_state->setError($form['spv'], $this->t('Function %function_name expects %function_parameter_count parameters. %parameter_defined_count given.', ['%function_name' => $functionName, '%function_parameter_count' => $functionParamCount, '%parameter_defined_count' => $paramCount]));
+        $form_state->setError(
+          $form['spv'],
+          $this->t(
+            'Function %function_name expects %function_parameter_count parameters. %parameter_defined_count given.',
+            [
+              '%function_name' => $functionName,
+              '%function_parameter_count' => $functionParamCount,
+              '%parameter_defined_count' => $paramCount,
+            ]
+          )
+        );
       }
     }
   }
+
 }

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -117,11 +117,8 @@ class FormHelper {
    *   The form structure.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The current state of the form.
-   *
-   * @throws \ReflectionException
-   *   Function name specified cannot be reflected.
    */
-  public function validateByContentFunction(array &$form, FormStateInterface $form_state) {
+  public function validateByContentFunction(array &$form, FormStateInterface $form_state): void {
     if ("bycontentfunction" === $form_state->getValue(['spv', 'method'])) {
 
       // Get function name and parameters defined in the flow task.
@@ -142,7 +139,19 @@ class FormHelper {
         return;
       }
       // Get the number of parameters for the defined function.
-      $functionParamCount = (new \ReflectionFunction($functionName))->getNumberOfRequiredParameters();
+      try {
+        $functionParamCount = (new \ReflectionFunction($functionName))->getNumberOfRequiredParameters();
+      }
+      catch (\ReflectionException $e) {
+        $form_state->setError(
+          $form['spv'],
+          $this->t('Unable to reflect function %function_name: @error', [
+            '%function_name' => $functionName,
+            '@error' => $e->getMessage(),
+          ])
+        );
+        return;
+      }
 
       // The maestro execute method always adds 2 parameters
       // (queueID and processID) when handling the "bycontentfunction" case.
@@ -169,6 +178,10 @@ class FormHelper {
         );
       }
     }
+  }
+
+  function hestvest(): void {
+    die('f');
   }
 
 }

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -102,7 +102,6 @@ class FormHelper {
     if ('template_edit_task' === $form_id) {
       $form['#validate'][] = [$this, "validateByContentFunction"];
     }
-
   }
 
   /**

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -155,9 +155,9 @@ class FormHelper {
         );
         $this->logger->error('Error reflecting function %function_name: %message', [
           '%function_name' => $functionName,
-           %message' => $e->getMessage(),
+          '%message' => $e->getMessage(),
            // Add the full exception to the context for future reference.
-           'exception' => $e,
+          'exception' => $e,
         ]);
         return;
       }

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -99,7 +99,7 @@ class FormHelper {
       ];
     }
 
-    if ("template_edit_task" === $form_id) {
+    if ('template_edit_task' === $form_id) {
       $form['#validate'][] = [$this, "validateByContentFunction"];
     }
 

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -141,7 +141,7 @@ class FormHelper {
         $form_state->setError($form['spv'], $this->t('Function %function_name does not exist', ['%function_name' => $functionName]));
         return;
       }
-      
+
       // Get the number of parameters for the defined function.
       try {
         $functionParamCount = (new \ReflectionFunction($functionName))->getNumberOfRequiredParameters();

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -4,23 +4,18 @@ namespace Drupal\os2forms_selvbetjening\Helper;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
-use Drupal\Core\Logger\LoggerChannelInterface;
+use Drupal\Core\Logger\LoggerChannel;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
-use Psr\Log\LoggerAwareTrait;
-use Psr\Log\LoggerInterface;
-use Psr\Log\LoggerTrait;
 
 /**
  * Form Helper class, for altering forms.
  */
-final class FormHelper implements LoggerInterface {
+class FormHelper {
   use StringTranslationTrait;
-  use LoggerAwareTrait;
-  use LoggerTrait;
 
   /**
    * Constructor.
@@ -30,8 +25,7 @@ final class FormHelper implements LoggerInterface {
    * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
    *   Logger.
    */
-  public function __construct(private readonly AccountInterface $account, LoggerChannelInterface $logger) {
-    $this->setLogger($logger);
+  public function __construct(private readonly AccountInterface $account, private readonly LoggerChannel $logger) {
   }
 
   /**
@@ -147,6 +141,7 @@ final class FormHelper implements LoggerInterface {
         $form_state->setError($form['spv'], $this->t('Function %function_name does not exist', ['%function_name' => $functionName]));
         return;
       }
+      $this->logger->error('test hest error');
       // Get the number of parameters for the defined function.
       try {
         $functionParamCount = (new \ReflectionFunction($functionName))->getNumberOfRequiredParameters();
@@ -158,7 +153,7 @@ final class FormHelper implements LoggerInterface {
             '%function_name' => $functionName,
           ])
         );
-        $this->error($e->getMessage(), $e->getTrace());
+        $this->logger->error($e->getMessage(), $e->getTrace());
         return;
       }
 
@@ -187,17 +182,6 @@ final class FormHelper implements LoggerInterface {
         );
       }
     }
-  }
-
-  /**
-   * {@inheritdoc}
-   *
-   * @phpstan-param mixed $level
-   * @phpstan-param string $message
-   * @phpstan-param array<string, mixed> $context
-   */
-  public function log($level, $message, array $context = []): void {
-    $this->logger?->log($level, $message, $context);
   }
 
 }

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -27,8 +27,10 @@ final class FormHelper implements LoggerInterface {
    *
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current user.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   Logger.
    */
-  public function __construct(private readonly AccountInterface $account, LoggerChannelInterface $logger,) {
+  public function __construct(private readonly AccountInterface $account, LoggerChannelInterface $logger) {
     $this->setLogger($logger);
   }
 

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -180,8 +180,4 @@ class FormHelper {
     }
   }
 
-  function hestvest(): void {
-    die('f');
-  }
-
 }

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -22,7 +22,7 @@ class FormHelper {
    *
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Current user.
-   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   * @param \Drupal\Core\Logger\LoggerChannel $logger
    *   Logger.
    */
   public function __construct(private readonly AccountInterface $account, private readonly LoggerChannel $logger) {


### PR DESCRIPTION
[#4239](https://leantime.itkdev.dk/#/tickets/showTicket/4239)

Sets out to prevent errors caused by providing invalid number of parameters when configuring a SetProcessVariable task in a Maestro flow.

