### PR TITLE
4239-ext: Add phpcs single quotes rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede apostrof-regel til kodestandarder [PR-414](https://github.com/itk-dev/os2forms_selvbetjening/pull/414)
 * Tilføjede maestro bycontentfunction validation [PR-413](https://github.com/itk-dev/os2forms_selvbetjening/pull/413).
 
 ## [4.1.0] 2025-04-08

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -21,4 +21,5 @@
   </rule>
 
   <rule ref="DrupalPractice"/>
+  <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired"/>
 </ruleset>

--- a/web/modules/custom/os2forms_email_handler/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
+++ b/web/modules/custom/os2forms_email_handler/src/Plugin/WebformHandler/OS2FormsEmailWebformHandler.php
@@ -214,7 +214,7 @@ class OS2FormsEmailWebformHandler extends EmailWebformHandler implements Contain
     $units = ['KB', 'MB', 'GB'];
 
     // Get number of units and units from threshold.
-    preg_match("/(?<num>\d+)(?<units>kb|mb|gb)$/i", $threshold, $matches);
+    preg_match('/(?<num>\d+)(?<units>kb|mb|gb)$/i', $threshold, $matches);
 
     $size = (int) $matches['num'];
     $unit = strtoupper($matches['units']);
@@ -272,7 +272,7 @@ class OS2FormsEmailWebformHandler extends EmailWebformHandler implements Contain
         $notificationMessage['subject'] = $this->t('File size submission warning');
 
         $notificationMessage['body'] = $this->t(
-          "<p>Dear @name</p><p>Submission @submission attempted sending an email with a large total file size of attachments surpassing @threshold for handler @handler (@handler_id) on form @form (@form_id).</p>", [
+          '<p>Dear @name</p><p>Submission @submission attempted sending an email with a large total file size of attachments surpassing @threshold for handler @handler (@handler_id) on form @form (@form_id).</p>', [
             '@name' => $emailAddress,
             '@submission' => $context['link'],
             '@handler' => $context['@handler'],

--- a/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Helper/FormHelper.php
@@ -100,7 +100,7 @@ class FormHelper {
     }
 
     if ('template_edit_task' === $form_id) {
-      $form['#validate'][] = [$this, "validateByContentFunction"];
+      $form['#validate'][] = [$this, 'validateByContentFunction'];
     }
   }
 
@@ -119,7 +119,7 @@ class FormHelper {
    *   The current state of the form.
    */
   public function validateByContentFunction(array &$form, FormStateInterface $form_state): void {
-    if ("bycontentfunction" === $form_state->getValue(['spv', 'method'])) {
+    if ('bycontentfunction' === $form_state->getValue(['spv', 'method'])) {
 
       // Get function name and parameters defined in the flow task.
       $value = $form_state->getValue(['spv', 'variable_value']);


### PR DESCRIPTION
Extension of PR [#4239](https://github.com/itk-dev/os2forms_selvbetjening/pull/413)

This PR implements the ```Squiz.Strings.DoubleQuoteUsage.NotRequired``` rule in the phpcs configuration to enforce consistent use of quotation marks across the codebase.
