### PR TITLE
5112: Add link to byfunction option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 * Tilføjede apostrof-regel til kodestandarder [PR-423](https://github.com/itk-dev/os2forms_selvbetjening/pull/423).
 * Tilføjede maestro bycontentfunction validation [PR-423](https://github.com/itk-dev/os2forms_selvbetjening/pull/423).
+* Tilføjede oversætbar bycontentfunction hjælpetekst [PR-443](https://github.com/itk-dev/os2forms_selvbetjening/pull/443).
 
 ## [4.2.1] 2025-05-06
 

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
@@ -15,6 +15,13 @@ use Drupal\os2forms_selvbetjening\Helper\FormHelper;
  */
 function os2forms_selvbetjening_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
   Drupal::service(FormHelper::class)->formAlter($form, $form_state, $form_id);
+
+  // Set out to edit maestro field edit ajax modal
+  if ($form_id === 'template_edit_task') {
+    if (isset($form['spv']['method']['#options']['bycontentfunction'])) {
+      $form['spv']['method']['#options']['bycontentfunction'] .= t('. Read more: ') . '<a href="https://os2forms.os2.eu/variabler-i-flow" target="_blank">https://os2forms.os2.eu/variabler-i-flow</a>';
+    }
+  }
 }
 
 /**

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
@@ -19,7 +19,7 @@ function os2forms_selvbetjening_form_alter(array &$form, FormStateInterface $for
   // Set out to edit maestro field edit ajax modal
   if ($form_id === 'template_edit_task') {
     if (isset($form['spv']['method']['#options']['bycontentfunction'])) {
-      $form['spv']['method']['#options']['bycontentfunction'] .= t('. Read more: ') . '<a href="https://os2forms.os2.eu/variabler-i-flow" target="_blank">https://os2forms.os2.eu/variabler-i-flow</a>';
+      $form['spv']['method']['#options']['bycontentfunction'] .= t('. Read more: <a href="https://os2forms.os2.eu/variabler-i-flow" target="_blank">https://os2forms.os2.eu/variabler-i-flow</a>');
     }
   }
 }

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
@@ -16,7 +16,7 @@ use Drupal\os2forms_selvbetjening\Helper\FormHelper;
 function os2forms_selvbetjening_form_alter(array &$form, FormStateInterface $form_state, string $form_id) {
   Drupal::service(FormHelper::class)->formAlter($form, $form_state, $form_id);
 
-  // Set out to edit maestro field edit ajax modal
+  // Set out to edit maestro field edit ajax modal.
   if ($form_id === 'template_edit_task') {
     if (isset($form['spv']['method']['#options']['bycontentfunction'])) {
       $form['spv']['method']['#options']['bycontentfunction'] .= t('. Read more: <a href="https://os2forms.os2.eu/variabler-i-flow" target="_blank">https://os2forms.os2.eu/variabler-i-flow</a>');


### PR DESCRIPTION
[#5112](https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/5112)

Sets out to enrich the option text of "By function" in maestro's "Define variable"-element options.

Added "Read more: <a href="https://os2forms.os2.eu/variabler-i-flow" target="_blank">https://os2forms.os2.eu/variabler-i-flow</a>"

The text (including link) has been made translatable, so it can be edited by the customer at their will.

<img width="1075" height="154" alt="Screenshot 2025-08-14 at 12 43 07" src="https://github.com/user-attachments/assets/f544acbd-1dc1-4d59-babb-c888f883bfe5" />
