### PR TITLE
#391: Added javascript to DAWA address autocomplete elements handling…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* Tilføjede javascript til `DAWA adresse`-elementer så de håndterer kommaer.
+
 ## [4.5.0] 2025-07-03
 
 * Tilføjede `site_status_message`-modulet.

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.libraries.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.libraries.yml
@@ -7,3 +7,10 @@ author_bulk_assignment:
   css:
     theme:
       assets/css/author_bulk_assignment.css: {}
+dawa_address_autocomplete:
+  version: 1.x
+  js:
+    js/dawa_address_autocomplete.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
@@ -26,6 +26,10 @@ function os2forms_selvbetjening_webform_element_alter(array &$element, FormState
   if ('webform_more' === $element['#type']) {
     $element['#attributes']['class'][] = 'js-form-item';
   }
+
+  if ('os2forms_dawa_address' === $element['#type']) {
+    $element['#attached']['library'][] = 'os2forms_selvbetjening/dawa_address_autocomplete';
+  }
 }
 
 /**


### PR DESCRIPTION
… commas

https://leantime.itkdev.dk/#/tickets/showTicket/5232

Drupal core autocomplete splits on commas. https://www.drupal.org/project/drupal/issues/2821181

* Overrides Drupal autocomplete splitValues to avoid splitting on commas.