### PR TITLE
Feature/example more forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
   Opdaterede projektskabelon.
 * [PR-488](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/488)
   Tilføjede eksempelformularer.
+  Tilføjede webform core eksempelformularer.
 
 ## [5.1.5] 2025-04-16
 

--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -1,4 +1,4 @@
-  langcode: da
+langcode: da
 settings:
   default_status: open
   default_categories: {}

--- a/config/sync/webform.settings.yml
+++ b/config/sync/webform.settings.yml
@@ -1,4 +1,4 @@
-langcode: da
+  langcode: da
 settings:
   default_status: open
   default_categories: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_computed.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_computed.yml
@@ -72,8 +72,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_computed
-title: 'Hidden and computed elements'
-description: 'Examples of hidden value storage and computed (Twig) elements'
+title: "Hidden and computed elements"
+description: "Examples of hidden value storage and computed (Twig) elements"
 categories: {}
 elements: |-
   example_hidden:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_computed.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_computed.yml
@@ -1,0 +1,276 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_hidden:
+        encrypt: true
+        encrypt_profile: webform
+      example_value:
+        encrypt: true
+        encrypt_profile: webform
+      example_computed_twig:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_computed
+title: 'Hidden and computed elements'
+description: 'Examples of hidden value storage and computed (Twig) elements'
+categories: {}
+elements: |-
+  example_hidden:
+    '#type': hidden
+    '#title': Hidden
+    '#value': hidden_default_value
+  example_value:
+    '#type': value
+    '#title': Value
+    '#value': stored_default_value
+  example_computed_twig:
+    '#type': webform_computed_twig
+    '#title': 'Computed (Twig)'
+    '#template': 'The current date is {{ "now"|date("Y-m-d") }}'
+    '#ajax': true
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_contact.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_contact.yml
@@ -1,0 +1,301 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_email:
+        encrypt: true
+        encrypt_profile: webform
+      example_tel:
+        encrypt: true
+        encrypt_profile: webform
+      example_url:
+        encrypt: true
+        encrypt_profile: webform
+      example_email_confirm:
+        encrypt: true
+        encrypt_profile: webform
+      example_address:
+        encrypt: true
+        encrypt_profile: webform
+      example_webform_address:
+        encrypt: true
+        encrypt_profile: webform
+      example_contact:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_contact
+title: 'Contact and address elements'
+description: 'Examples of contact information elements: email, telephone, URL and address composites'
+categories: {}
+elements: |-
+  example_email:
+    '#type': email
+    '#title': Email
+    '#placeholder': 'user@example.com'
+  example_tel:
+    '#type': tel
+    '#title': Telephone
+    '#placeholder': '+45 12345678'
+  example_url:
+    '#type': url
+    '#title': URL
+    '#placeholder': 'https://example.com'
+  example_email_confirm:
+    '#type': webform_email_confirm
+    '#title': 'Confirm email'
+  example_address:
+    '#type': address
+    '#title': Address
+    '#default_value':
+      country_code: DK
+  example_webform_address:
+    '#type': webform_address
+    '#title': 'Webform address'
+  example_contact:
+    '#type': webform_contact
+    '#title': Contact
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_contact.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_contact.yml
@@ -84,8 +84,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_contact
-title: 'Contact and address elements'
-description: 'Examples of contact information elements: email, telephone, URL and address composites'
+title: "Contact and address elements"
+description: "Examples of contact information elements: email, telephone, URL and address composites"
 categories: {}
 elements: |-
   example_email:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_datetime.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_datetime.yml
@@ -1,0 +1,283 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_date:
+        encrypt: true
+        encrypt_profile: webform
+      example_datelist:
+        encrypt: true
+        encrypt_profile: webform
+      example_datetime:
+        encrypt: true
+        encrypt_profile: webform
+      example_time:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_datetime
+title: 'Date and time elements'
+description: 'Examples of date and time input elements'
+categories: {}
+elements: |-
+  example_date:
+    '#type': date
+    '#title': Date
+  example_datelist:
+    '#type': datelist
+    '#title': 'Date list'
+    '#date_part_order':
+      - year
+      - month
+      - day
+  example_datetime:
+    '#type': datetime
+    '#title': 'Date and time'
+  example_time:
+    '#type': webform_time
+    '#title': Time
+    '#time_format': 'H:i'
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_datetime.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_datetime.yml
@@ -75,8 +75,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_datetime
-title: 'Date and time elements'
-description: 'Examples of date and time input elements'
+title: "Date and time elements"
+description: "Examples of date and time input elements"
 categories: {}
 elements: |-
   example_date:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_files.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_files.yml
@@ -78,8 +78,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_files
-title: 'File upload elements'
-description: 'Examples of file upload elements: general files, images, audio, video and documents'
+title: "File upload elements"
+description: "Examples of file upload elements: general files, images, audio, video and documents"
 categories: {}
 elements: |-
   example_managed_file:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_files.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_files.yml
@@ -1,0 +1,291 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_managed_file:
+        encrypt: true
+        encrypt_profile: webform
+      example_image_file:
+        encrypt: true
+        encrypt_profile: webform
+      example_audio_file:
+        encrypt: true
+        encrypt_profile: webform
+      example_video_file:
+        encrypt: true
+        encrypt_profile: webform
+      example_document_file:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_files
+title: 'File upload elements'
+description: 'Examples of file upload elements: general files, images, audio, video and documents'
+categories: {}
+elements: |-
+  example_managed_file:
+    '#type': managed_file
+    '#title': 'File upload'
+    '#file_extensions': 'txt pdf doc docx'
+    '#max_filesize': '10'
+  example_image_file:
+    '#type': webform_image_file
+    '#title': 'Image upload'
+    '#file_extensions': 'jpg jpeg png gif'
+    '#max_filesize': '5'
+  example_audio_file:
+    '#type': webform_audio_file
+    '#title': 'Audio upload'
+    '#file_extensions': 'mp3 wav ogg'
+  example_video_file:
+    '#type': webform_video_file
+    '#title': 'Video upload'
+    '#file_extensions': 'mp4 webm'
+  example_document_file:
+    '#type': webform_document_file
+    '#title': 'Document upload'
+    '#file_extensions': 'pdf doc docx xls xlsx'
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_layout.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_layout.yml
@@ -1,0 +1,418 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      page_containers:
+        encrypt: true
+        encrypt_profile: webform
+      example_container:
+        encrypt: true
+        encrypt_profile: webform
+      container_child:
+        encrypt: true
+        encrypt_profile: webform
+      example_details:
+        encrypt: true
+        encrypt_profile: webform
+      details_child:
+        encrypt: true
+        encrypt_profile: webform
+      example_fieldset:
+        encrypt: true
+        encrypt_profile: webform
+      fieldset_child:
+        encrypt: true
+        encrypt_profile: webform
+      example_flexbox:
+        encrypt: true
+        encrypt_profile: webform
+      flexbox_child_1:
+        encrypt: true
+        encrypt_profile: webform
+      flexbox_child_2:
+        encrypt: true
+        encrypt_profile: webform
+      example_section:
+        encrypt: true
+        encrypt_profile: webform
+      section_child:
+        encrypt: true
+        encrypt_profile: webform
+      page_display:
+        encrypt: true
+        encrypt_profile: webform
+      example_vertical_tabs:
+        encrypt: true
+        encrypt_profile: webform
+      vertical_tab_1:
+        encrypt: true
+        encrypt_profile: webform
+      tab1_child:
+        encrypt: true
+        encrypt_profile: webform
+      vertical_tab_2:
+        encrypt: true
+        encrypt_profile: webform
+      tab2_child:
+        encrypt: true
+        encrypt_profile: webform
+      page_tables:
+        encrypt: true
+        encrypt_profile: webform
+      example_webform_table:
+        encrypt: true
+        encrypt_profile: webform
+      table_row_1:
+        encrypt: true
+        encrypt_profile: webform
+      row1_name:
+        encrypt: true
+        encrypt_profile: webform
+      row1_value:
+        encrypt: true
+        encrypt_profile: webform
+      example_table_sort:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_layout
+title: 'Layout and structure elements'
+description: 'Examples of layout and structural elements: containers, sections, tables, markup, wizard pages and display helpers'
+categories: {}
+elements: |-
+  page_containers:
+    '#type': webform_wizard_page
+    '#title': 'Container elements'
+    example_container:
+      '#type': container
+      '#title': Container
+      container_child:
+        '#type': textfield
+        '#title': 'Field inside container'
+    example_details:
+      '#type': details
+      '#title': Details
+      '#open': true
+      details_child:
+        '#type': textfield
+        '#title': 'Field inside details'
+    example_fieldset:
+      '#type': fieldset
+      '#title': Fieldset
+      fieldset_child:
+        '#type': textfield
+        '#title': 'Field inside fieldset'
+    example_flexbox:
+      '#type': webform_flexbox
+      flexbox_child_1:
+        '#type': textfield
+        '#title': 'Left field'
+      flexbox_child_2:
+        '#type': textfield
+        '#title': 'Right field'
+    example_section:
+      '#type': webform_section
+      '#title': Section
+      section_child:
+        '#type': textfield
+        '#title': 'Field inside section'
+  page_display:
+    '#type': webform_wizard_page
+    '#title': 'Display elements'
+    example_horizontal_rule:
+      '#type': webform_horizontal_rule
+    example_more:
+      '#type': webform_more
+      '#more': '<p>This text is hidden until the user clicks to expand it.</p>'
+    example_markup:
+      '#type': webform_markup
+      '#markup': '<p>This is example markup displayed in the form.</p>'
+    example_vertical_tabs:
+      '#type': vertical_tabs
+      '#title': 'Vertical tabs'
+    vertical_tab_1:
+      '#type': details
+      '#title': 'Tab 1'
+      '#group': example_vertical_tabs
+      tab1_child:
+        '#type': textfield
+        '#title': 'Field in tab 1'
+    vertical_tab_2:
+      '#type': details
+      '#title': 'Tab 2'
+      '#group': example_vertical_tabs
+      tab2_child:
+        '#type': textfield
+        '#title': 'Field in tab 2'
+  page_tables:
+    '#type': webform_wizard_page
+    '#title': 'Table elements'
+    example_table:
+      '#type': table
+      '#header':
+        - 'Column 1'
+        - 'Column 2'
+    example_webform_table:
+      '#type': webform_table
+      '#header':
+        - Name
+        - Value
+      table_row_1:
+        '#type': webform_table_row
+        row1_name:
+          '#type': textfield
+          '#title': Name
+        row1_value:
+          '#type': textfield
+          '#title': Value
+    example_table_sort:
+      '#type': webform_table_sort
+      '#title': 'Table sort'
+      '#options':
+        item_1: 'First item'
+        item_2: 'Second item'
+        item_3: 'Third item'
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_layout.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_layout.yml
@@ -135,8 +135,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_layout
-title: 'Layout and structure elements'
-description: 'Examples of layout and structural elements: containers, sections, tables, markup, wizard pages and display helpers'
+title: "Layout and structure elements"
+description: "Examples of layout and structural elements: containers, sections, tables, markup, wizard pages and display helpers"
 categories: {}
 elements: |-
   page_containers:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_misc.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_misc.yml
@@ -81,8 +81,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_misc
-title: 'Miscellaneous elements'
-description: 'Examples of specialized elements: signature, terms of service, composites, CAPTCHA and other utility elements'
+title: "Miscellaneous elements"
+description: "Examples of specialized elements: signature, terms of service, composites, CAPTCHA and other utility elements"
 categories: {}
 elements: |-
   example_webform_element:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_misc.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_misc.yml
@@ -1,0 +1,321 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_signature:
+        encrypt: true
+        encrypt_profile: webform
+      example_terms_of_service:
+        encrypt: true
+        encrypt_profile: webform
+      example_custom_composite:
+        encrypt: true
+        encrypt_profile: webform
+      example_language_select:
+        encrypt: true
+        encrypt_profile: webform
+      example_machine_name_source:
+        encrypt: true
+        encrypt_profile: webform
+      example_machine_name:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_misc
+title: 'Miscellaneous elements'
+description: 'Examples of specialized elements: signature, terms of service, composites, CAPTCHA and other utility elements'
+categories: {}
+elements: |-
+  example_webform_element:
+    '#type': webform_element
+    '#title': 'Generic element'
+    '#markup': '<p>A generic webform element for display purposes.</p>'
+  example_actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': Send
+  example_signature:
+    '#type': webform_signature
+    '#title': Signature
+  example_terms_of_service:
+    '#type': webform_terms_of_service
+    '#title': 'Terms of service'
+    '#terms_type': modal
+    '#terms_content': 'These are the example terms of service. By checking the box you agree to these terms.'
+  example_custom_composite:
+    '#type': webform_custom_composite
+    '#title': 'Custom composite'
+    '#element':
+      composite_name:
+        '#type': textfield
+        '#title': Name
+      composite_age:
+        '#type': number
+        '#title': Age
+  example_variant:
+    '#type': webform_variant
+    '#title': Variant
+  example_captcha:
+    '#type': captcha
+    '#captcha_type': default
+  example_language_select:
+    '#type': language_select
+    '#title': Language
+  example_machine_name_source:
+    '#type': textfield
+    '#title': 'Label for machine name'
+  example_machine_name:
+    '#type': machine_name
+    '#title': 'Machine name'
+    '#machine_name':
+      source:
+        - example_machine_name_source
+  example_view:
+    '#type': view
+    '#title': 'Embedded view'
+    '#name': content_recent
+    '#display_id': default
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_numeric.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_numeric.yml
@@ -75,8 +75,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_numeric
-title: 'Numeric and rating elements'
-description: 'Examples of numeric input elements: numbers, ranges, scales and ratings'
+title: "Numeric and rating elements"
+description: "Examples of numeric input elements: numbers, ranges, scales and ratings"
 categories: {}
 elements: |-
   example_number:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_numeric.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_numeric.yml
@@ -1,0 +1,291 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_number:
+        encrypt: true
+        encrypt_profile: webform
+      example_range:
+        encrypt: true
+        encrypt_profile: webform
+      example_scale:
+        encrypt: true
+        encrypt_profile: webform
+      example_rating:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_numeric
+title: 'Numeric and rating elements'
+description: 'Examples of numeric input elements: numbers, ranges, scales and ratings'
+categories: {}
+elements: |-
+  example_number:
+    '#type': number
+    '#title': Number
+    '#min': 0
+    '#max': 100
+    '#step': 1
+  example_range:
+    '#type': range
+    '#title': Range
+    '#min': 0
+    '#max': 100
+    '#step': 5
+    '#output': right
+    '#output__field_suffix': '%'
+  example_scale:
+    '#type': webform_scale
+    '#title': Scale
+    '#min': 1
+    '#max': 10
+    '#min_text': 'Not likely'
+    '#max_text': 'Very likely'
+  example_rating:
+    '#type': webform_rating
+    '#title': Rating
+    '#star_size': medium
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_options.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_options.yml
@@ -96,8 +96,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_options
-title: 'Option and selection elements'
-description: 'Examples of option-based elements: dropdowns, radios, checkboxes, likert scales and taxonomy term selectors'
+title: "Option and selection elements"
+description: "Examples of option-based elements: dropdowns, radios, checkboxes, likert scales and taxonomy term selectors"
 categories: {}
 elements: |-
   example_select:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_options.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_options.yml
@@ -1,0 +1,365 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_select:
+        encrypt: true
+        encrypt_profile: webform
+      example_radios:
+        encrypt: true
+        encrypt_profile: webform
+      example_checkbox:
+        encrypt: true
+        encrypt_profile: webform
+      example_checkboxes:
+        encrypt: true
+        encrypt_profile: webform
+      example_select_other:
+        encrypt: true
+        encrypt_profile: webform
+      example_radios_other:
+        encrypt: true
+        encrypt_profile: webform
+      example_checkboxes_other:
+        encrypt: true
+        encrypt_profile: webform
+      example_tableselect:
+        encrypt: true
+        encrypt_profile: webform
+      example_likert:
+        encrypt: true
+        encrypt_profile: webform
+      example_term_select:
+        encrypt: true
+        encrypt_profile: webform
+      example_term_checkboxes:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_options
+title: 'Option and selection elements'
+description: 'Examples of option-based elements: dropdowns, radios, checkboxes, likert scales and taxonomy term selectors'
+categories: {}
+elements: |-
+  example_select:
+    '#type': select
+    '#title': Select
+    '#options':
+      option_a: 'Option A'
+      option_b: 'Option B'
+      option_c: 'Option C'
+  example_radios:
+    '#type': radios
+    '#title': Radios
+    '#options':
+      yes: 'Yes'
+      no: 'No'
+      maybe: Maybe
+  example_checkbox:
+    '#type': checkbox
+    '#title': 'Single checkbox'
+  example_checkboxes:
+    '#type': checkboxes
+    '#title': Checkboxes
+    '#options':
+      red: Red
+      green: Green
+      blue: Blue
+  example_select_other:
+    '#type': webform_select_other
+    '#title': 'Select (with other)'
+    '#options':
+      cat: Cat
+      dog: Dog
+    '#other__placeholder': 'Specify other'
+  example_radios_other:
+    '#type': webform_radios_other
+    '#title': 'Radios (with other)'
+    '#options':
+      morning: Morning
+      afternoon: Afternoon
+      evening: Evening
+    '#other__placeholder': 'Specify other'
+  example_checkboxes_other:
+    '#type': webform_checkboxes_other
+    '#title': 'Checkboxes (with other)'
+    '#options':
+      email_contact: Email
+      phone_contact: Phone
+      sms_contact: SMS
+    '#other__placeholder': 'Specify other'
+  example_tableselect:
+    '#type': tableselect
+    '#title': 'Table select'
+    '#options':
+      row_1:
+        column_1: 'Row 1, Col 1'
+        column_2: 'Row 1, Col 2'
+      row_2:
+        column_1: 'Row 2, Col 1'
+        column_2: 'Row 2, Col 2'
+  example_likert:
+    '#type': webform_likert
+    '#title': Likert
+    '#questions':
+      q1: 'The service was fast'
+      q2: 'The staff was helpful'
+      q3: 'The quality was good'
+    '#answers':
+      1: 'Strongly disagree'
+      2: Disagree
+      3: Neutral
+      4: Agree
+      5: 'Strongly agree'
+  example_term_select:
+    '#type': webform_term_select
+    '#title': 'Taxonomy term select'
+    '#vocabulary': tags
+  example_term_checkboxes:
+    '#type': webform_term_checkboxes
+    '#title': 'Taxonomy term checkboxes'
+    '#vocabulary': tags
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_text.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_text.yml
@@ -1,0 +1,284 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_textfield:
+        encrypt: true
+        encrypt_profile: webform
+      example_textarea:
+        encrypt: true
+        encrypt_profile: webform
+      example_text_format:
+        encrypt: true
+        encrypt_profile: webform
+      example_autocomplete:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_core_text
+title: 'Text input elements'
+description: 'Examples of text-based input elements: plain text, formatted text and autocomplete'
+categories: {}
+elements: |-
+  example_textfield:
+    '#type': textfield
+    '#title': 'Text field'
+    '#placeholder': 'Enter text here'
+  example_textarea:
+    '#type': textarea
+    '#title': 'Text area'
+    '#rows': 5
+  example_text_format:
+    '#type': text_format
+    '#title': 'Formatted text'
+  example_autocomplete:
+    '#type': webform_autocomplete
+    '#title': Autocomplete
+    '#autocomplete_items':
+      - 'Option A'
+      - 'Option B'
+      - 'Option C'
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_text.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_core_text.yml
@@ -75,8 +75,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_core_text
-title: 'Text input elements'
-description: 'Examples of text-based input elements: plain text, formatted text and autocomplete'
+title: "Text input elements"
+description: "Examples of text-based input elements: plain text, formatted text and autocomplete"
 categories: {}
 elements: |-
   example_textfield:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_sub_mod_fields.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_sub_mod_fields.yml
@@ -90,8 +90,8 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_webform_sub_mod_fields
-title: 'Webform sub-module elements'
-description: 'Examples of elements from webform sub-modules. Elements only render when their sub-module is enabled. See the markup at the top of this form for required modules.'
+title: "Webform sub-module elements"
+description: "Examples of elements from webform sub-modules. Elements only render when their sub-module is enabled. See the markup at the top of this form for required modules."
 categories: {}
 elements: |-
   required_modules_info:

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_sub_mod_fields.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/config/install/webform.webform.itkdev_ex_webform_sub_mod_fields.yml
@@ -1,0 +1,365 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_webform_core_fields
+third_party_settings:
+  os2forms_permissions_by_term:
+    settings:
+      1: "1"
+      2: 0
+  webform_encrypt:
+    element:
+      example_buttons:
+        encrypt: true
+        encrypt_profile: webform
+      example_buttons_other:
+        encrypt: true
+        encrypt_profile: webform
+      example_image_select:
+        encrypt: true
+        encrypt_profile: webform
+      example_location_geocomplete:
+        encrypt: true
+        encrypt_profile: webform
+      example_location_places:
+        encrypt: true
+        encrypt_profile: webform
+      example_options_custom:
+        encrypt: true
+        encrypt_profile: webform
+      example_options_custom_entity:
+        encrypt: true
+        encrypt_profile: webform
+      example_toggle:
+        encrypt: true
+        encrypt_profile: webform
+      example_toggles:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ""
+    os2forms_nemid:
+      session_type: ""
+      webform_type: ""
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ""
+          element_key: ""
+          error_message: ""
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ""
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ""
+  webform_entity_print:
+    template:
+      header: ""
+      footer: ""
+      css: ""
+      os2form_header: ""
+      os2form_colophon: ""
+      os2form_footer: ""
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ""
+        link_attributes: {}
+      word_docx:
+        enabled: false
+        link_text: ""
+        link_attributes: {}
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_webform_sub_mod_fields
+title: 'Webform sub-module elements'
+description: 'Examples of elements from webform sub-modules. Elements only render when their sub-module is enabled. See the markup at the top of this form for required modules.'
+categories: {}
+elements: |-
+  required_modules_info:
+    '#type': webform_markup
+    '#markup': |
+      <details>
+        <summary><strong>Required modules for sub-module elements</strong></summary>
+        <p>Elements on this form require the following webform sub-modules to be enabled. Elements from disabled modules will not render.</p>
+        <table>
+          <thead><tr><th>Module</th><th>Element type</th></tr></thead>
+          <tbody>
+            <tr><td><code>webform_jqueryui_buttons</code></td><td>webform_buttons, webform_buttons_other</td></tr>
+            <tr><td><code>webform_image_select</code></td><td>webform_image_select</td></tr>
+            <tr><td><code>webform_location_geocomplete</code></td><td>webform_location_geocomplete</td></tr>
+            <tr><td><code>webform_location_places</code></td><td>webform_location_places</td></tr>
+            <tr><td><code>webform_options_custom</code></td><td>webform_options_custom, webform_options_custom_entity</td></tr>
+            <tr><td><code>webform_toggles</code></td><td>webform_toggle, webform_toggles</td></tr>
+          </tbody>
+        </table>
+      </details>
+  example_buttons:
+    '#type': webform_buttons
+    '#title': Buttons
+    '#options':
+      yes: 'Yes'
+      no: 'No'
+      maybe: Maybe
+  example_buttons_other:
+    '#type': webform_buttons_other
+    '#title': 'Buttons (with other)'
+    '#options':
+      option_a: 'Option A'
+      option_b: 'Option B'
+      option_c: 'Option C'
+    '#other__placeholder': 'Specify other'
+  example_image_select:
+    '#type': webform_image_select
+    '#title': 'Image select'
+    '#show_label': true
+    '#images':
+      image_1:
+        text: 'Image 1'
+        src: 'https://placehold.co/150x100?text=1'
+      image_2:
+        text: 'Image 2'
+        src: 'https://placehold.co/150x100?text=2'
+      image_3:
+        text: 'Image 3'
+        src: 'https://placehold.co/150x100?text=3'
+  example_location_geocomplete:
+    '#type': webform_location_geocomplete
+    '#title': 'Location (Geocomplete)'
+  example_location_places:
+    '#type': webform_location_places
+    '#title': 'Location (Places)'
+  example_options_custom:
+    '#type': webform_options_custom
+    '#title': 'Custom options'
+    '#options':
+      option_1: 'Custom option 1'
+      option_2: 'Custom option 2'
+      option_3: 'Custom option 3'
+  example_options_custom_entity:
+    '#type': webform_options_custom_entity
+    '#title': 'Custom options (entity)'
+    '#options':
+      option_1: 'Entity option 1'
+      option_2: 'Entity option 2'
+  example_toggle:
+    '#type': webform_toggle
+    '#title': 'Toggle option'
+    '#toggle_theme': light
+    '#toggle_size': medium
+    '#on_text': 'Yes'
+    '#off_text': 'No'
+  example_toggles:
+    '#type': webform_toggles
+    '#title': 'Toggle options'
+    '#toggle_theme': light
+    '#toggle_size': medium
+    '#on_text': 'Yes'
+    '#off_text': 'No'
+    '#options':
+      notify_email: 'Email notifications'
+      notify_sms: 'SMS notifications'
+      notify_push: 'Push notifications'
+css: ""
+javascript: ""
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ""
+  ajax_effect: ""
+  ajax_speed: null
+  page: true
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
+  form_title: both
+  form_submit_once: false
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ""
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ""
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
+  share: false
+  share_node: false
+  share_theme_name: ""
+  share_title: true
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
+  submission_log: false
+  submission_excluded_elements: {}
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
+  autofill: false
+  autofill_message: ""
+  autofill_excluded_elements: {}
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ""
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ""
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
+  wizard_toggle: false
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
+  confirmation_type: page
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
+  confirmation_back: true
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ""
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ""
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {}
+    permissions: {}
+  view_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  purge_any:
+    roles: {}
+    users: {}
+    permissions: {}
+  view_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  update_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  delete_own:
+    roles: {}
+    users: {}
+    permissions: {}
+  administer:
+    roles: {}
+    users: {}
+    permissions: {}
+  test:
+    roles: {}
+    users: {}
+    permissions: {}
+  configuration:
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.info.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.info.yml
@@ -1,0 +1,7 @@
+name: "Webform core field examples"
+type: module
+description: "Example forms demonstrating all available core webform elements"
+package: ITK Dev example forms
+core_version_requirement: ^10 || ^11
+dependencies:
+  - itkdev_example_forms:itkdev_example_forms

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
@@ -2,7 +2,8 @@
 
 /**
  * @file
- * Install, update and uninstall functions for the itkdev_ex_webform_core_fields module.
+ * Install, update and uninstall functions for the
+ * itkdev_ex_webform_core_fields module.
  */
 
 use Drupal\itkdev_example_forms\Fixture\UserAffiliationTermFixture;

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
@@ -10,13 +10,10 @@ use Drupal\itkdev_example_forms\WebformHelper;
 use Drupal\webform\Entity\Webform;
 
 /**
- * Implements hook_install().
+ * Get all webform IDs managed by this module.
  */
-function itkdev_ex_webform_core_fields_install(bool $is_syncing): void {
-  /** @var \Drupal\itkdev_example_forms\WebformHelper $helper */
-  $helper = \Drupal::service(WebformHelper::class);
-
-  $webformIds = [
+function _itkdev_ex_webform_core_fields_webform_ids(): array {
+  return [
     'itkdev_ex_webform_core_text',
     'itkdev_ex_webform_core_numeric',
     'itkdev_ex_webform_core_options',
@@ -26,9 +23,18 @@ function itkdev_ex_webform_core_fields_install(bool $is_syncing): void {
     'itkdev_ex_webform_core_layout',
     'itkdev_ex_webform_core_computed',
     'itkdev_ex_webform_core_misc',
+    'itkdev_ex_webform_sub_mod_fields',
   ];
+}
 
-  foreach ($webformIds as $webformId) {
+/**
+ * Implements hook_install().
+ */
+function itkdev_ex_webform_core_fields_install(bool $is_syncing): void {
+  /** @var \Drupal\itkdev_example_forms\WebformHelper $helper */
+  $helper = \Drupal::service(WebformHelper::class);
+
+  foreach (_itkdev_ex_webform_core_fields_webform_ids() as $webformId) {
     if ($webform = Webform::load($webformId)) {
       $helper->createWebformPage($webform, [
         'title' => $webform->label(),
@@ -36,6 +42,29 @@ function itkdev_ex_webform_core_fields_install(bool $is_syncing): void {
           UserAffiliationTermFixture::ITK_DEVELOPMENT,
         ],
       ]);
+    }
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ *
+ * Enforced dependency config removal does not clean up the webform serial
+ * tracking table or the page nodes created in hook_install(). Both must be
+ * deleted explicitly to avoid errors on reinstall.
+ */
+function itkdev_ex_webform_core_fields_uninstall(bool $is_syncing): void {
+  /** @var \Drupal\itkdev_example_forms\WebformHelper $helper */
+  $helper = \Drupal::service(WebformHelper::class);
+
+  foreach (_itkdev_ex_webform_core_fields_webform_ids() as $webformId) {
+    // Delete the webform page node.
+    if ($page = $helper->loadWebformPage($webformId)) {
+      $page->delete();
+    }
+    // Delete the webform entity (also cleans up the webform serial table).
+    if ($webform = Webform::load($webformId)) {
+      $webform->delete();
     }
   }
 }

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the itkdev_ex_webform_core_fields module.
+ */
+
+use Drupal\itkdev_example_forms\Fixture\UserAffiliationTermFixture;
+use Drupal\itkdev_example_forms\WebformHelper;
+use Drupal\webform\Entity\Webform;
+
+/**
+ * Implements hook_install().
+ */
+function itkdev_ex_webform_core_fields_install(bool $is_syncing): void {
+  /** @var \Drupal\itkdev_example_forms\WebformHelper $helper */
+  $helper = \Drupal::service(WebformHelper::class);
+
+  $webformIds = [
+    'itkdev_ex_webform_core_text',
+    'itkdev_ex_webform_core_numeric',
+    'itkdev_ex_webform_core_options',
+    'itkdev_ex_webform_core_datetime',
+    'itkdev_ex_webform_core_files',
+    'itkdev_ex_webform_core_contact',
+    'itkdev_ex_webform_core_layout',
+    'itkdev_ex_webform_core_computed',
+    'itkdev_ex_webform_core_misc',
+  ];
+
+  foreach ($webformIds as $webformId) {
+    if ($webform = Webform::load($webformId)) {
+      $helper->createWebformPage($webform, [
+        'title' => $webform->label(),
+        WebformHelper::FIELD_OS2FORMS_PERMISSIONS => [
+          UserAffiliationTermFixture::ITK_DEVELOPMENT,
+        ],
+      ]);
+    }
+  }
+}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_webform_core_fields/itkdev_ex_webform_core_fields.install
@@ -2,8 +2,7 @@
 
 /**
  * @file
- * Install, update and uninstall functions for the
- * itkdev_ex_webform_core_fields module.
+ * Install and update functions for the itkdev_ex_webform_core_fields module.
  */
 
 use Drupal\itkdev_example_forms\Fixture\UserAffiliationTermFixture;


### PR DESCRIPTION
- Add itkdev_ex_webform_core_fields submodule that adds webforms holding all core webform fields that are not currently excluded in webform.settings.yml.
- Groups the fields by type resulting in 10 webform config files.
- Adds install and uninstall hooks