### PR TITLE
Added devel module and patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     "require-dev": {
         "custom/itkdev_example_forms": "^1.0",
         "drupal/core-dev": "^10",
+        "drupal/devel": "^5.4",
         "drupal/mail_debugger": "^1.4",
         "ergebnis/composer-normalize": "^2.43",
         "mglaman/phpstan-drupal": "^1.2",
@@ -161,12 +162,16 @@
         },
         "patches": {
             "drupal/config_entity_revisions": {
+                "patches/drupal/config_entity_revisions/missing-use-statement.patch": "patches/drupal/config_entity_revisions/missing-use-statement.patch",
                 "webform_revisions_install called twice during site:install --existing-config": "patches/drupal/config_entity_revisions/webform_revisions.install.patch"
             },
             "drupal/core": {
                 "Get CKEditor 5 to work in (modal) dialogs (https://www.drupal.org/project/drupal/issues/3274937)": "https://www.drupal.org/files/issues/2024-07-02/3351603-30.patch",
                 "Allow conditionals based on computed twig (https://www.drupal.org/project/webform/issues/3481569)": "https://www.drupal.org/files/issues/2024-11-05/revert-core-states.patch",
                 "Use date fields for views filters (https://www.drupal.org/project/drupal/issues/2648950)": "https://www.drupal.org/files/issues/2025-06-24/2648950-293.patch"
+            },
+            "drupal/devel": {
+                "patches/drupal/devel/devel_generate.patch": "patches/drupal/devel/devel_generate.patch"
             },
             "drupal/entity_print": {
                 "Add page count https://www.drupal.org/project/entity_print/issues/2823430": "https://www.drupal.org/files/issues/2023-07-10/entity_print-dompdf_page_count-2823430-14.patch"
@@ -183,7 +188,8 @@
             },
             "drupal/webform": {
                 "Fix issue with webform search containing æøå": "https://www.drupal.org/files/issues/2024-02-26/3415445-cant-load-non-english_0.patch",
-                "Email handler shows fieldset and section titles despite all children fields etc are excluded (https://www.drupal.org/project/webform/issues/3482544)": "patches/drupal/webform/email_handler_titles_despite_exluded_element.patch"
+                "Email handler shows fieldset and section titles despite all children fields etc are excluded (https://www.drupal.org/project/webform/issues/3482544)": "patches/drupal/webform/email_handler_titles_despite_exluded_element.patch",
+                "patches/drupal/webform/devel_generate.patch": "patches/drupal/webform/devel_generate.patch"
             },
             "os2forms/os2forms": {
                 "Hide additional os2forms webform settings page": "patches/drupal/os2forms/os2forms_hide_additional_settings_page.diff"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f37d792585b1b7ee35027bdfb14cd42",
+    "content-hash": "5db9ae6f59099928fe37b846f0f618dd",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -17938,6 +17938,281 @@
             "time": "2025-11-11T04:32:07+00:00"
         },
         {
+            "name": "doctrine/common",
+            "version": "3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/common.git",
+                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/d9ea4a54ca2586db781f0265d36bea731ac66ec5",
+                "reference": "d9ea4a54ca2586db781f0265d36bea731ac66ec5",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/persistence": "^2.0 || ^3.0 || ^4.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9.0 || ^10.0",
+                "doctrine/collections": "^1",
+                "phpstan/phpstan": "^1.4.1",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5.20 || ^8.5 || ^9.0",
+                "squizlabs/php_codesniffer": "^3.0",
+                "symfony/phpunit-bridge": "^6.1",
+                "vimeo/psalm": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, proxies and much more.",
+            "homepage": "https://www.doctrine-project.org/projects/common.html",
+            "keywords": [
+                "common",
+                "doctrine",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/common/issues",
+                "source": "https://github.com/doctrine/common/tree/3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcommon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-01T22:12:03+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-29T07:11:08+00:00"
+        },
+        {
+            "name": "doctrine/persistence",
+            "version": "4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/persistence.git",
+                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
+                "reference": "b9c49ad3558bb77ef973f4e173f2e9c2eca9be09",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/event-manager": "^1 || ^2",
+                "php": "^8.1",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.58 || ^12",
+                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0",
+                "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Persistence\\": "src/Persistence"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.",
+            "homepage": "https://www.doctrine-project.org/projects/persistence.html",
+            "keywords": [
+                "mapper",
+                "object",
+                "odm",
+                "orm",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/persistence/issues",
+                "source": "https://github.com/doctrine/persistence/tree/4.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-10-16T20:13:18+00:00"
+        },
+        {
             "name": "drupal/coder",
             "version": "8.3.31",
             "source": {
@@ -18099,6 +18374,67 @@
                 "source": "https://github.com/drupal/core-dev/tree/10.5.9"
             },
             "time": "2026-01-12T11:59:52+00:00"
+        },
+        {
+            "name": "drupal/devel",
+            "version": "5.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/devel.git",
+                "reference": "5.4.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/devel-5.4.0.zip",
+                "reference": "5.4.0",
+                "shasum": "fc14fe1c396dbff661f9d13e6e3171d9ab781a46"
+            },
+            "require": {
+                "doctrine/common": "^2.7 || ^3.4",
+                "drupal/core": "^10.3 || ^11 || ^12",
+                "php": ">=8.1",
+                "symfony/var-dumper": "^4 || ^5 || ^6 || ^7"
+            },
+            "conflict": {
+                "drupal/core": "<10.3",
+                "drush/drush": "<12.5.1"
+            },
+            "require-dev": {
+                "drupal/navigation_extra_tools": "1.0.x-dev",
+                "drush/drush": "^13",
+                "firephp/firephp-core": "^0.5.3"
+            },
+            "suggest": {
+                "drupal/kint": "Kint provides an informative display of arrays/objects. Useful for debugging and developing."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "5.4.0",
+                    "datestamp": "1752755621",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "moshe weitzman",
+                    "homepage": "https://www.drupal.org/user/23"
+                }
+            ],
+            "description": "Various blocks, pages, and functions for developers.",
+            "homepage": "https://www.drupal.org/project/devel",
+            "support": {
+                "source": "https://gitlab.com/drupalspoons/devel",
+                "issues": "https://gitlab.com/drupalspoons/devel/-/issues",
+                "slack": "https://drupal.slack.com/archives/C012WAW1MH6"
+            }
         },
         {
             "name": "drupal/mail_debugger",

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -139,3 +139,10 @@ docker compose up -d
 ```
 
 to reload the OIDC configuration.
+
+## Generating webform submissions
+
+``` shell
+docker compose exec phpfpm vendor/bin/drush pm:install devel_generate
+docker compose exec phpfpm vendor/bin/drush --help
+```

--- a/patches/drupal/config_entity_revisions/missing-use-statement.patch
+++ b/patches/drupal/config_entity_revisions/missing-use-statement.patch
@@ -1,0 +1,11 @@
+diff --git a/modules/webform_revisions/src/Entity/WebformRevisionsSubmission.php b/modules/webform_revisions/src/Entity/WebformRevisionsSubmission.php
+index 8620fd5..082c600 100644
+--- a/modules/webform_revisions/src/Entity/WebformRevisionsSubmission.php
++++ b/modules/webform_revisions/src/Entity/WebformRevisionsSubmission.php
+@@ -5,5 +5,6 @@ namespace Drupal\webform_revisions\Entity;
+ use Drupal\Component\Utility\Crypt;
+ use Drupal\config_entity_revisions\ConfigEntityRevisionsInterface;
+ use Drupal\Core\Entity\EntityStorageInterface;
++use Drupal\Core\Serialization\Yaml;
+ use Drupal\webform\Entity\WebformSubmission;
+ use Drupal\webform_revisions\Controller\WebformRevisionsController;

--- a/patches/drupal/devel/devel_generate.patch
+++ b/patches/drupal/devel/devel_generate.patch
@@ -1,0 +1,16 @@
+diff --git a/devel_generate/src/DevelGenerateBase.php b/devel_generate/src/DevelGenerateBase.php
+index ff527f3..8d0c261 100644
+--- a/devel_generate/src/DevelGenerateBase.php
++++ b/devel_generate/src/DevelGenerateBase.php
+@@ -22,11 +22,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
+  */
+ abstract class DevelGenerateBase extends PluginBase implements DevelGenerateBaseInterface {
+ 
+-  /**
+-   * The entity type manager service.
+-   */
+-  protected EntityTypeManagerInterface $entityTypeManager;
+-
+   /**
+    * The language manager.
+    */

--- a/patches/drupal/webform/devel_generate.patch
+++ b/patches/drupal/webform/devel_generate.patch
@@ -1,0 +1,58 @@
+diff --git a/src/Plugin/DevelGenerate/WebformSubmissionDevelGenerate.php b/src/Plugin/DevelGenerate/WebformSubmissionDevelGenerate.php
+index c072ae2..077ab36 100644
+--- a/src/Plugin/DevelGenerate/WebformSubmissionDevelGenerate.php
++++ b/src/Plugin/DevelGenerate/WebformSubmissionDevelGenerate.php
+@@ -52,13 +52,6 @@ class WebformSubmissionDevelGenerate extends DevelGenerateBase implements Contai
+    */
+   protected $database;
+
+-  /**
+-   * The entity type manager.
+-   *
+-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+-   */
+-  protected $entityTypeManager;
+-
+   /**
+    * The webform submission generation service.
+    *
+@@ -90,7 +83,8 @@ class WebformSubmissionDevelGenerate extends DevelGenerateBase implements Contai
+   /**
+    * {@inheritdoc}
+    */
+-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
++  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): static
++  {
+     $instance = new static($configuration, $plugin_id, $plugin_definition);
+     $instance->request = $container->get('request_stack')->getCurrentRequest();
+     $instance->database = $container->get('database');
+@@ -105,7 +99,8 @@ public static function create(ContainerInterface $container, array $configuratio
+   /**
+    * {@inheritdoc}
+    */
+-  public function settingsForm(array $form, FormStateInterface $form_state) {
++  public function settingsForm(array $form, FormStateInterface $form_state): array
++  {
+     $form['message'] = [
+       '#type' => 'webform_message',
+       '#message_message' => $this->t('Please note that no emails will be sent while generating webform submissions.'),
+@@ -230,7 +225,8 @@ public function validateForm(array $form, FormStateInterface $form_state) {
+   /**
+    * {@inheritdoc}
+    */
+-  public function generateElements(array $values) {
++  public function generateElements(array $values): void
++  {
+     $this->generateSubmissions($values);
+   }
+
+@@ -348,7 +344,8 @@ protected function generateSubmission(&$results) {
+   /**
+    * {@inheritdoc}
+    */
+-  public function validateDrushParams(array $args, array $options = []) {
++  public function validateDrushParams(array $args, array $options = []): array
++  {
+     $webform_id = array_shift($args);
+     $webform_ids = [$webform_id => $webform_id];
+     $values = [


### PR DESCRIPTION
Adds [the Devel module](https://www.drupal.org/project/devel) and hence `devel_generate`: https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/496/changes#diff-d9657425e036fb0ad2912c2c24ea793648eb86de5b40aa0844276dd08ed01d87

A number, more specifically 3, of patches are used to make `devel` and friends behave (we cannot yet use [devel 5.5.0](https://www.drupal.org/project/devel/releases/5.5.0) which may resolve (some of) these issues).
