### PR TITLE
Strip links from attachments with digital signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* [PR-497](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/497)
+  Fjerende links fra OS2Forms Attachments der er indstillet til digital
+  signering.
 * [PR-494](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/494)
   Undlod at eksportere eksempelformularkonfiguration
 * [PR-489](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/489)

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/README.md
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/README.md
@@ -1,0 +1,46 @@
+# itkdev_ex_digital_signature
+
+Digital signature example forms.
+
+Read more about Digital Signatures here:
+[OS2Forms Digital Signature module](https://github.com/OS2Forms/os2forms/tree/develop/modules/os2forms_digital_signature#how-does-it-work)
+
+## Install
+
+```php
+drush pm:install itkdev_ex_digital_signature
+```
+
+## Why
+
+When an attachment element is configured for digital signature, the generated
+PDF must contain no clickable links. That includes header, footer, colophon
+and element values.
+
+Note, that there's no actual digital signature handler in the example forms.
+This is because whether an attachment is to be signed or not is
+determined by the attachment-element.
+
+## Which elements
+
+Several elements may be rendered as links. As of writing this, that is:
+
+* email
+* tel
+* url
+* markup
+* managed_file
+* webform_document_file
+* webform_audio_file
+* webform_video_file
+* webform_image_file
+* webform_term_select
+* webform_term_checkboxes
+
+Note that this list only contains enabled elements.
+
+## How it's done
+
+1. Mark when a signature PDF is being generated, see `DigitalSignatureFlaggingPrintBuilder`.
+2. Strip `<a>` from the rendered HTML, see `DigitalSignatureLinkStripperSubscriber`.
+3. Render file element values as plain filenames, see `CustomViewBuilderWebformSubmission::overrideFormatsForPdf()`.

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/os2forms_attachment.os2forms_attachment_component.digital_signature_colophon.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/os2forms_attachment.os2forms_attachment_component.digital_signature_colophon.yml
@@ -1,0 +1,10 @@
+langcode: da
+status: true
+dependencies:
+  enforced:
+    module:
+      - itkdev_ex_digital_signature
+id: digital_signature_colophon
+label: 'Digital signature colophon'
+body: '<p>[webform_submission:completed:custom:d. F Y]</p><p><strong>Aarhus Kommune</strong><br />Rådhuspladsen 2<br />8000 Aarhus C</p><p><a href="https://www.dr.dk/">Hjemmeside</a></p>'
+type: colophon

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/os2forms_attachment.os2forms_attachment_component.digital_signature_colophon.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/os2forms_attachment.os2forms_attachment_component.digital_signature_colophon.yml
@@ -5,6 +5,6 @@ dependencies:
     module:
       - itkdev_ex_digital_signature
 id: digital_signature_colophon
-label: 'Digital signature colophon'
+label: "Digital signature colophon"
 body: '<p>[webform_submission:completed:custom:d. F Y]</p><p><strong>Aarhus Kommune</strong><br />Rådhuspladsen 2<br />8000 Aarhus C</p><p><a href="https://www.dr.dk/">Hjemmeside</a></p>'
 type: colophon

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_000.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_000.yml
@@ -14,45 +14,45 @@ third_party_settings:
   os2forms:
     os2forms_email_handler:
       enabled: 0
-      email_recipients: ''
+      email_recipients: ""
     os2forms_nemid:
-      session_type: ''
-      webform_type: ''
+      session_type: ""
+      webform_type: ""
       nemlogin_auto_redirect: 0
       os2forms_nemlogin_openid_connect:
         authentication_settings:
-          user_claim: ''
-          element_key: ''
-          error_message: ''
+          user_claim: ""
+          element_key: ""
+          error_message: ""
     os2forms_nemid_address_protection:
       nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
-      nemlogin_hide_message: ''
+      nemlogin_hide_message: ""
     os2forms_rest_api:
       allowed_users: null
     os2forms_sync:
       publish: 0
     os2forms_webform_submission_log:
-      emails: ''
+      emails: ""
   webform_entity_print:
     template:
-      header: ''
-      footer: ''
-      css: ''
+      header: ""
+      footer: ""
+      css: ""
       os2form_header: empty
       os2form_colophon: digital_signature_colophon
       os2form_footer: empty
     export_types:
       pdf:
         enabled: true
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
       word_docx:
         enabled: false
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
   os2forms_permissions_by_term:
     settings:
-      1: '1'
+      1: "1"
       2: 0
   webform_encrypt:
     element:
@@ -72,9 +72,9 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_digital_signature_000
-title: 'Webform with links and digital signature'
+title: "Webform with links and digital signature"
 description: '<p>Webform with links, both via the URL-element and the <a href="https://selvbetjening.local.itkdev.dk/da/admin/structure/webform/config/os2forms_attachment_component">digital_signature_colophon</a>.</p><p>Attachment element IS configured to be for digital signature.</p><p>Shows how links are stripped.</p>'
-categories: {  }
+categories: {}
 elements: |-
   navn:
     '#type': textfield
@@ -92,32 +92,32 @@ elements: |-
     '#excluded_elements': {  }
     '#exclude_empty': 0
     '#exclude_empty_checkbox': 0
-css: ''
-javascript: ''
+css: ""
+javascript: ""
 settings:
   ajax: false
   ajax_scroll_top: form
-  ajax_progress_type: ''
-  ajax_effect: ''
+  ajax_progress_type: ""
+  ajax_effect: ""
   ajax_speed: null
   page: true
-  page_submit_path: ''
-  page_confirm_path: ''
-  page_theme_name: ''
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
   form_title: both
   form_submit_once: false
-  form_open_message: ''
-  form_close_message: ''
-  form_exception_message: ''
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
   form_previous_submissions: true
   form_confidential: false
-  form_confidential_message: ''
+  form_confidential_message: ""
   form_disable_remote_addr: false
   form_convert_anonymous: false
   form_prepopulate: false
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
-  form_prepopulate_source_entity_type: ''
+  form_prepopulate_source_entity_type: ""
   form_unsaved: false
   form_disable_back: false
   form_submit_back: false
@@ -129,91 +129,91 @@ settings:
   form_details_toggle: false
   form_reset: false
   form_access_denied: default
-  form_access_denied_title: ''
-  form_access_denied_message: ''
-  form_access_denied_attributes: {  }
-  form_file_limit: ''
-  form_attributes: {  }
-  form_method: ''
-  form_action: ''
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
   share: false
   share_node: false
-  share_theme_name: ''
+  share_theme_name: ""
   share_title: true
-  share_page_body_attributes: {  }
-  submission_label: ''
-  submission_exception_message: ''
-  submission_locked_message: ''
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
   submission_log: false
-  submission_excluded_elements: {  }
+  submission_excluded_elements: {}
   submission_exclude_empty: false
   submission_exclude_empty_checkbox: false
-  submission_views: {  }
-  submission_views_replace: {  }
-  submission_user_columns: {  }
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
   submission_user_duplicate: false
   submission_access_denied: default
-  submission_access_denied_title: ''
-  submission_access_denied_message: ''
-  submission_access_denied_attributes: {  }
-  previous_submission_message: ''
-  previous_submissions_message: ''
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
   autofill: false
-  autofill_message: ''
-  autofill_excluded_elements: {  }
+  autofill_message: ""
+  autofill_excluded_elements: {}
   wizard_progress_bar: true
   wizard_progress_pages: false
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_start_label: ''
+  wizard_start_label: ""
   wizard_preview_link: false
   wizard_confirmation: true
-  wizard_confirmation_label: ''
+  wizard_confirmation_label: ""
   wizard_auto_forward: true
   wizard_auto_forward_hide_next_button: false
   wizard_keyboard: true
-  wizard_track: ''
-  wizard_prev_button_label: ''
-  wizard_next_button_label: ''
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
   wizard_toggle: false
-  wizard_toggle_show_label: ''
-  wizard_toggle_hide_label: ''
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
   wizard_page_type: container
   wizard_page_title_tag: h2
   preview: 0
-  preview_label: ''
-  preview_title: ''
-  preview_message: ''
-  preview_attributes: {  }
-  preview_excluded_elements: {  }
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
   draft: none
   draft_multiple: false
   draft_auto_save: false
-  draft_saved_message: ''
-  draft_loaded_message: ''
-  draft_pending_single_message: ''
-  draft_pending_multiple_message: ''
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
   confirmation_type: page
-  confirmation_url: ''
-  confirmation_title: ''
-  confirmation_message: ''
-  confirmation_attributes: {  }
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
   confirmation_back: true
-  confirmation_back_label: ''
-  confirmation_back_attributes: {  }
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
   confirmation_exclude_query: false
   confirmation_exclude_token: false
   confirmation_update: false
   limit_total: null
   limit_total_interval: null
-  limit_total_message: ''
+  limit_total_message: ""
   limit_total_unique: false
   limit_user: null
   limit_user_interval: null
-  limit_user_message: ''
+  limit_user_message: ""
   limit_user_unique: false
   entity_limit_total: null
   entity_limit_total_interval: null
@@ -233,47 +233,47 @@ access:
     roles:
       - anonymous
       - authenticated
-    users: {  }
-    permissions: {  }
+    users: {}
+    permissions: {}
   view_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   purge_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   view_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   administer:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   test:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   configuration:
-    roles: {  }
-    users: {  }
-    permissions: {  }
-handlers: {  }
-variants: {  }
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_000.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_000.yml
@@ -1,0 +1,279 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_digital_signature
+third_party_settings:
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ''
+    os2forms_nemid:
+      session_type: ''
+      webform_type: ''
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ''
+          element_key: ''
+          error_message: ''
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ''
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ''
+  webform_entity_print:
+    template:
+      header: ''
+      footer: ''
+      css: ''
+      os2form_header: empty
+      os2form_colophon: digital_signature_colophon
+      os2form_footer: empty
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ''
+        link_attributes: {  }
+      word_docx:
+        enabled: false
+        link_text: ''
+        link_attributes: {  }
+  os2forms_permissions_by_term:
+    settings:
+      1: '1'
+      2: 0
+  webform_encrypt:
+    element:
+      navn:
+        encrypt: true
+        encrypt_profile: webform
+      url_til_din_favoritside:
+        encrypt: true
+        encrypt_profile: webform
+      os2forms_attachment:
+        encrypt: true
+        encrypt_profile: webform
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_digital_signature_000
+title: 'Webform with links and digital signature'
+description: '<p>Webform with links, both via the URL-element and the <a href="https://selvbetjening.local.itkdev.dk/da/admin/structure/webform/config/os2forms_attachment_component">digital_signature_colophon</a>.</p><p>Attachment element IS configured to be for digital signature.</p><p>Shows how links are stripped.</p>'
+categories: {  }
+elements: |-
+  navn:
+    '#type': textfield
+    '#title': Navn
+    '#default_value': 'Jens Hansen'
+  url_til_din_favoritside:
+    '#type': url
+    '#title': 'URL til din favoritside'
+    '#default_value': 'https://www.dr.dk/'
+  os2forms_attachment:
+    '#type': os2forms_attachment
+    '#title': 'OS2Forms Attachment'
+    '#export_type': pdf
+    '#digital_signature': 1
+    '#excluded_elements': {  }
+    '#exclude_empty': 0
+    '#exclude_empty_checkbox': 0
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_001.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_001.yml
@@ -14,45 +14,45 @@ third_party_settings:
   os2forms:
     os2forms_email_handler:
       enabled: 0
-      email_recipients: ''
+      email_recipients: ""
     os2forms_nemid:
-      session_type: ''
-      webform_type: ''
+      session_type: ""
+      webform_type: ""
       nemlogin_auto_redirect: 0
       os2forms_nemlogin_openid_connect:
         authentication_settings:
-          user_claim: ''
-          element_key: ''
-          error_message: ''
+          user_claim: ""
+          element_key: ""
+          error_message: ""
     os2forms_nemid_address_protection:
       nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
-      nemlogin_hide_message: ''
+      nemlogin_hide_message: ""
     os2forms_rest_api:
       allowed_users: null
     os2forms_sync:
       publish: 0
     os2forms_webform_submission_log:
-      emails: ''
+      emails: ""
   webform_entity_print:
     template:
-      header: ''
-      footer: ''
-      css: ''
+      header: ""
+      footer: ""
+      css: ""
       os2form_header: empty
       os2form_colophon: digital_signature_colophon
       os2form_footer: empty
     export_types:
       pdf:
         enabled: true
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
       word_docx:
         enabled: false
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
   os2forms_permissions_by_term:
     settings:
-      1: '1'
+      1: "1"
       2: 0
   webform_encrypt:
     element:
@@ -72,9 +72,9 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_digital_signature_001
-title: 'Webform with links without digital signature'
+title: "Webform with links without digital signature"
 description: '<p>Webform with links, both via the URL-element and the <a href="https://selvbetjening.local.itkdev.dk/da/admin/structure/webform/config/os2forms_attachment_component">digital_signature_colophon</a>.</p><p>Attachment element is NOT configured to be for digital signature.</p><p>Shows how links are NOT stripped.</p>'
-categories: {  }
+categories: {}
 elements: |-
   navn:
     '#type': textfield
@@ -92,32 +92,32 @@ elements: |-
     '#excluded_elements': {  }
     '#exclude_empty': 0
     '#exclude_empty_checkbox': 0
-css: ''
-javascript: ''
+css: ""
+javascript: ""
 settings:
   ajax: false
   ajax_scroll_top: form
-  ajax_progress_type: ''
-  ajax_effect: ''
+  ajax_progress_type: ""
+  ajax_effect: ""
   ajax_speed: null
   page: true
-  page_submit_path: ''
-  page_confirm_path: ''
-  page_theme_name: ''
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
   form_title: both
   form_submit_once: false
-  form_open_message: ''
-  form_close_message: ''
-  form_exception_message: ''
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
   form_previous_submissions: true
   form_confidential: false
-  form_confidential_message: ''
+  form_confidential_message: ""
   form_disable_remote_addr: false
   form_convert_anonymous: false
   form_prepopulate: false
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
-  form_prepopulate_source_entity_type: ''
+  form_prepopulate_source_entity_type: ""
   form_unsaved: false
   form_disable_back: false
   form_submit_back: false
@@ -129,91 +129,91 @@ settings:
   form_details_toggle: false
   form_reset: false
   form_access_denied: default
-  form_access_denied_title: ''
-  form_access_denied_message: ''
-  form_access_denied_attributes: {  }
-  form_file_limit: ''
-  form_attributes: {  }
-  form_method: ''
-  form_action: ''
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
   share: false
   share_node: false
-  share_theme_name: ''
+  share_theme_name: ""
   share_title: true
-  share_page_body_attributes: {  }
-  submission_label: ''
-  submission_exception_message: ''
-  submission_locked_message: ''
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
   submission_log: false
-  submission_excluded_elements: {  }
+  submission_excluded_elements: {}
   submission_exclude_empty: false
   submission_exclude_empty_checkbox: false
-  submission_views: {  }
-  submission_views_replace: {  }
-  submission_user_columns: {  }
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
   submission_user_duplicate: false
   submission_access_denied: default
-  submission_access_denied_title: ''
-  submission_access_denied_message: ''
-  submission_access_denied_attributes: {  }
-  previous_submission_message: ''
-  previous_submissions_message: ''
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
   autofill: false
-  autofill_message: ''
-  autofill_excluded_elements: {  }
+  autofill_message: ""
+  autofill_excluded_elements: {}
   wizard_progress_bar: true
   wizard_progress_pages: false
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_start_label: ''
+  wizard_start_label: ""
   wizard_preview_link: false
   wizard_confirmation: true
-  wizard_confirmation_label: ''
+  wizard_confirmation_label: ""
   wizard_auto_forward: true
   wizard_auto_forward_hide_next_button: false
   wizard_keyboard: true
-  wizard_track: ''
-  wizard_prev_button_label: ''
-  wizard_next_button_label: ''
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
   wizard_toggle: false
-  wizard_toggle_show_label: ''
-  wizard_toggle_hide_label: ''
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
   wizard_page_type: container
   wizard_page_title_tag: h2
   preview: 0
-  preview_label: ''
-  preview_title: ''
-  preview_message: ''
-  preview_attributes: {  }
-  preview_excluded_elements: {  }
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
   draft: none
   draft_multiple: false
   draft_auto_save: false
-  draft_saved_message: ''
-  draft_loaded_message: ''
-  draft_pending_single_message: ''
-  draft_pending_multiple_message: ''
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
   confirmation_type: page
-  confirmation_url: ''
-  confirmation_title: ''
-  confirmation_message: ''
-  confirmation_attributes: {  }
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
   confirmation_back: true
-  confirmation_back_label: ''
-  confirmation_back_attributes: {  }
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
   confirmation_exclude_query: false
   confirmation_exclude_token: false
   confirmation_update: false
   limit_total: null
   limit_total_interval: null
-  limit_total_message: ''
+  limit_total_message: ""
   limit_total_unique: false
   limit_user: null
   limit_user_interval: null
-  limit_user_message: ''
+  limit_user_message: ""
   limit_user_unique: false
   entity_limit_total: null
   entity_limit_total_interval: null
@@ -233,47 +233,47 @@ access:
     roles:
       - anonymous
       - authenticated
-    users: {  }
-    permissions: {  }
+    users: {}
+    permissions: {}
   view_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   purge_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   view_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   administer:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   test:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   configuration:
-    roles: {  }
-    users: {  }
-    permissions: {  }
-handlers: {  }
-variants: {  }
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_001.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_001.yml
@@ -1,0 +1,279 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_digital_signature
+third_party_settings:
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ''
+    os2forms_nemid:
+      session_type: ''
+      webform_type: ''
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ''
+          element_key: ''
+          error_message: ''
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ''
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ''
+  webform_entity_print:
+    template:
+      header: ''
+      footer: ''
+      css: ''
+      os2form_header: empty
+      os2form_colophon: digital_signature_colophon
+      os2form_footer: empty
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ''
+        link_attributes: {  }
+      word_docx:
+        enabled: false
+        link_text: ''
+        link_attributes: {  }
+  os2forms_permissions_by_term:
+    settings:
+      1: '1'
+      2: 0
+  webform_encrypt:
+    element:
+      navn:
+        encrypt: true
+        encrypt_profile: webform
+      url_til_din_favoritside:
+        encrypt: true
+        encrypt_profile: webform
+      os2forms_attachment:
+        encrypt: true
+        encrypt_profile: webform
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_digital_signature_001
+title: 'Webform with links without digital signature'
+description: '<p>Webform with links, both via the URL-element and the <a href="https://selvbetjening.local.itkdev.dk/da/admin/structure/webform/config/os2forms_attachment_component">digital_signature_colophon</a>.</p><p>Attachment element is NOT configured to be for digital signature.</p><p>Shows how links are NOT stripped.</p>'
+categories: {  }
+elements: |-
+  navn:
+    '#type': textfield
+    '#title': Navn
+    '#default_value': 'Jens Hansen'
+  url_til_din_favoritside:
+    '#type': url
+    '#title': 'URL til din favoritside'
+    '#default_value': 'https://www.dr.dk/'
+  os2forms_attachment:
+    '#type': os2forms_attachment
+    '#title': 'OS2Forms Attachment'
+    '#export_type': pdf
+    '#digital_signature': 0
+    '#excluded_elements': {  }
+    '#exclude_empty': 0
+    '#exclude_empty_checkbox': 0
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_002.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_002.yml
@@ -25,6 +25,9 @@ third_party_settings:
       url_til_din_favoritside:
         encrypt: true
         encrypt_profile: webform
+      document_file:
+        encrypt: true
+        encrypt_profile: webform
       os2forms_attachment:
         encrypt: true
         encrypt_profile: webform
@@ -79,7 +82,7 @@ template: false
 archive: false
 id: itkdev_ex_digital_signature_002
 title: "Webform with links in container and digital signature"
-description: "<p>Webform with links both via the URL-element and within a container.</p><p>Attachment element IS configured to be for digital signature.</p>"
+description: "<p>Webform with links via the Telephone-, URL- and Document file-element. Some within a container to check up on nested elements.</p><p>Attachment element IS configured to be for digital signature.</p>"
 categories: {}
 elements: |-
   telefon:
@@ -97,6 +100,9 @@ elements: |-
       '#type': url
       '#title': 'URL til din favoritside'
       '#default_value': 'https://www.dr.dk/'
+    document_file:
+      '#type': webform_document_file
+      '#title': 'Document file'
   os2forms_attachment:
     '#type': os2forms_attachment
     '#title': 'OS2Forms Attachment'

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_002.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_002.yml
@@ -31,45 +31,45 @@ third_party_settings:
   os2forms:
     os2forms_email_handler:
       enabled: 0
-      email_recipients: ''
+      email_recipients: ""
     os2forms_nemid:
-      session_type: ''
-      webform_type: ''
+      session_type: ""
+      webform_type: ""
       nemlogin_auto_redirect: 0
       os2forms_nemlogin_openid_connect:
         authentication_settings:
-          user_claim: ''
-          element_key: ''
-          error_message: ''
+          user_claim: ""
+          element_key: ""
+          error_message: ""
     os2forms_nemid_address_protection:
       nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
-      nemlogin_hide_message: ''
+      nemlogin_hide_message: ""
     os2forms_rest_api:
       allowed_users: null
     os2forms_sync:
       publish: 0
     os2forms_webform_submission_log:
-      emails: ''
+      emails: ""
   webform_entity_print:
     template:
-      header: ''
-      footer: ''
-      css: ''
+      header: ""
+      footer: ""
+      css: ""
       os2form_header: empty
       os2form_colophon: empty
       os2form_footer: empty
     export_types:
       pdf:
         enabled: true
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
       word_docx:
         enabled: false
-        link_text: ''
-        link_attributes: {  }
+        link_text: ""
+        link_attributes: {}
   os2forms_permissions_by_term:
     settings:
-      1: '1'
+      1: "1"
       2: 0
 weight: 0
 open: null
@@ -78,9 +78,9 @@ uid: 1
 template: false
 archive: false
 id: itkdev_ex_digital_signature_002
-title: 'Webform with links in container and digital signature'
-description: '<p>Webform with links both via the URL-element and within a container.</p><p>Attachment element IS configured to be for digital signature.</p>'
-categories: {  }
+title: "Webform with links in container and digital signature"
+description: "<p>Webform with links both via the URL-element and within a container.</p><p>Attachment element IS configured to be for digital signature.</p>"
+categories: {}
 elements: |-
   telefon:
     '#type': tel
@@ -105,32 +105,32 @@ elements: |-
     '#excluded_elements': {  }
     '#exclude_empty': 0
     '#exclude_empty_checkbox': 0
-css: ''
-javascript: ''
+css: ""
+javascript: ""
 settings:
   ajax: false
   ajax_scroll_top: form
-  ajax_progress_type: ''
-  ajax_effect: ''
+  ajax_progress_type: ""
+  ajax_effect: ""
   ajax_speed: null
   page: true
-  page_submit_path: ''
-  page_confirm_path: ''
-  page_theme_name: ''
+  page_submit_path: ""
+  page_confirm_path: ""
+  page_theme_name: ""
   form_title: both
   form_submit_once: false
-  form_open_message: ''
-  form_close_message: ''
-  form_exception_message: ''
+  form_open_message: ""
+  form_close_message: ""
+  form_exception_message: ""
   form_previous_submissions: true
   form_confidential: false
-  form_confidential_message: ''
+  form_confidential_message: ""
   form_disable_remote_addr: false
   form_convert_anonymous: false
   form_prepopulate: false
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
-  form_prepopulate_source_entity_type: ''
+  form_prepopulate_source_entity_type: ""
   form_unsaved: false
   form_disable_back: false
   form_submit_back: false
@@ -142,91 +142,91 @@ settings:
   form_details_toggle: false
   form_reset: false
   form_access_denied: default
-  form_access_denied_title: ''
-  form_access_denied_message: ''
-  form_access_denied_attributes: {  }
-  form_file_limit: ''
-  form_attributes: {  }
-  form_method: ''
-  form_action: ''
+  form_access_denied_title: ""
+  form_access_denied_message: ""
+  form_access_denied_attributes: {}
+  form_file_limit: ""
+  form_attributes: {}
+  form_method: ""
+  form_action: ""
   share: false
   share_node: false
-  share_theme_name: ''
+  share_theme_name: ""
   share_title: true
-  share_page_body_attributes: {  }
-  submission_label: ''
-  submission_exception_message: ''
-  submission_locked_message: ''
+  share_page_body_attributes: {}
+  submission_label: ""
+  submission_exception_message: ""
+  submission_locked_message: ""
   submission_log: false
-  submission_excluded_elements: {  }
+  submission_excluded_elements: {}
   submission_exclude_empty: false
   submission_exclude_empty_checkbox: false
-  submission_views: {  }
-  submission_views_replace: {  }
-  submission_user_columns: {  }
+  submission_views: {}
+  submission_views_replace: {}
+  submission_user_columns: {}
   submission_user_duplicate: false
   submission_access_denied: default
-  submission_access_denied_title: ''
-  submission_access_denied_message: ''
-  submission_access_denied_attributes: {  }
-  previous_submission_message: ''
-  previous_submissions_message: ''
+  submission_access_denied_title: ""
+  submission_access_denied_message: ""
+  submission_access_denied_attributes: {}
+  previous_submission_message: ""
+  previous_submissions_message: ""
   autofill: false
-  autofill_message: ''
-  autofill_excluded_elements: {  }
+  autofill_message: ""
+  autofill_excluded_elements: {}
   wizard_progress_bar: true
   wizard_progress_pages: false
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_start_label: ''
+  wizard_start_label: ""
   wizard_preview_link: false
   wizard_confirmation: true
-  wizard_confirmation_label: ''
+  wizard_confirmation_label: ""
   wizard_auto_forward: true
   wizard_auto_forward_hide_next_button: false
   wizard_keyboard: true
-  wizard_track: ''
-  wizard_prev_button_label: ''
-  wizard_next_button_label: ''
+  wizard_track: ""
+  wizard_prev_button_label: ""
+  wizard_next_button_label: ""
   wizard_toggle: false
-  wizard_toggle_show_label: ''
-  wizard_toggle_hide_label: ''
+  wizard_toggle_show_label: ""
+  wizard_toggle_hide_label: ""
   wizard_page_type: container
   wizard_page_title_tag: h2
   preview: 0
-  preview_label: ''
-  preview_title: ''
-  preview_message: ''
-  preview_attributes: {  }
-  preview_excluded_elements: {  }
+  preview_label: ""
+  preview_title: ""
+  preview_message: ""
+  preview_attributes: {}
+  preview_excluded_elements: {}
   preview_exclude_empty: true
   preview_exclude_empty_checkbox: false
   draft: none
   draft_multiple: false
   draft_auto_save: false
-  draft_saved_message: ''
-  draft_loaded_message: ''
-  draft_pending_single_message: ''
-  draft_pending_multiple_message: ''
+  draft_saved_message: ""
+  draft_loaded_message: ""
+  draft_pending_single_message: ""
+  draft_pending_multiple_message: ""
   confirmation_type: page
-  confirmation_url: ''
-  confirmation_title: ''
-  confirmation_message: ''
-  confirmation_attributes: {  }
+  confirmation_url: ""
+  confirmation_title: ""
+  confirmation_message: ""
+  confirmation_attributes: {}
   confirmation_back: true
-  confirmation_back_label: ''
-  confirmation_back_attributes: {  }
+  confirmation_back_label: ""
+  confirmation_back_attributes: {}
   confirmation_exclude_query: false
   confirmation_exclude_token: false
   confirmation_update: false
   limit_total: null
   limit_total_interval: null
-  limit_total_message: ''
+  limit_total_message: ""
   limit_total_unique: false
   limit_user: null
   limit_user_interval: null
-  limit_user_message: ''
+  limit_user_message: ""
   limit_user_unique: false
   entity_limit_total: null
   entity_limit_total_interval: null
@@ -246,47 +246,47 @@ access:
     roles:
       - anonymous
       - authenticated
-    users: {  }
-    permissions: {  }
+    users: {}
+    permissions: {}
   view_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   purge_any:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   view_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   update_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   delete_own:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   administer:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   test:
-    roles: {  }
-    users: {  }
-    permissions: {  }
+    roles: {}
+    users: {}
+    permissions: {}
   configuration:
-    roles: {  }
-    users: {  }
-    permissions: {  }
-handlers: {  }
-variants: {  }
+    roles: {}
+    users: {}
+    permissions: {}
+handlers: {}
+variants: {}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_002.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/config/install/webform.webform.itkdev_ex_digital_signature_002.yml
@@ -1,0 +1,292 @@
+langcode: da
+status: open
+dependencies:
+  module:
+    - os2forms
+    - os2forms_permissions_by_term
+    - webform_encrypt
+    - webform_entity_print
+    - webform_revisions
+  enforced:
+    module:
+      - itkdev_ex_digital_signature
+third_party_settings:
+  webform_encrypt:
+    element:
+      telefon:
+        encrypt: true
+        encrypt_profile: webform
+      sektion:
+        encrypt: true
+        encrypt_profile: webform
+      navn:
+        encrypt: true
+        encrypt_profile: webform
+      url_til_din_favoritside:
+        encrypt: true
+        encrypt_profile: webform
+      os2forms_attachment:
+        encrypt: true
+        encrypt_profile: webform
+  os2forms:
+    os2forms_email_handler:
+      enabled: 0
+      email_recipients: ''
+    os2forms_nemid:
+      session_type: ''
+      webform_type: ''
+      nemlogin_auto_redirect: 0
+      os2forms_nemlogin_openid_connect:
+        authentication_settings:
+          user_claim: ''
+          element_key: ''
+          error_message: ''
+    os2forms_nemid_address_protection:
+      nemlogin_hide_form: os2forms_nemlogin_address_protection_default_behaviour
+      nemlogin_hide_message: ''
+    os2forms_rest_api:
+      allowed_users: null
+    os2forms_sync:
+      publish: 0
+    os2forms_webform_submission_log:
+      emails: ''
+  webform_entity_print:
+    template:
+      header: ''
+      footer: ''
+      css: ''
+      os2form_header: empty
+      os2form_colophon: empty
+      os2form_footer: empty
+    export_types:
+      pdf:
+        enabled: true
+        link_text: ''
+        link_attributes: {  }
+      word_docx:
+        enabled: false
+        link_text: ''
+        link_attributes: {  }
+  os2forms_permissions_by_term:
+    settings:
+      1: '1'
+      2: 0
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: itkdev_ex_digital_signature_002
+title: 'Webform with links in container and digital signature'
+description: '<p>Webform with links both via the URL-element and within a container.</p><p>Attachment element IS configured to be for digital signature.</p>'
+categories: {  }
+elements: |-
+  telefon:
+    '#type': tel
+    '#title': Telefon
+    '#default_value': '12341234'
+  sektion:
+    '#type': webform_section
+    '#title': Sektion
+    navn:
+      '#type': textfield
+      '#title': Navn
+      '#default_value': 'Jens Hansen'
+    url_til_din_favoritside:
+      '#type': url
+      '#title': 'URL til din favoritside'
+      '#default_value': 'https://www.dr.dk/'
+  os2forms_attachment:
+    '#type': os2forms_attachment
+    '#title': 'OS2Forms Attachment'
+    '#export_type': pdf
+    '#digital_signature': 1
+    '#excluded_elements': {  }
+    '#exclude_empty': 0
+    '#exclude_empty_checkbox': 0
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: page
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: ''
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: all
+  purge_days: 30
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers: {  }
+variants: {  }

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.info.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.info.yml
@@ -1,0 +1,8 @@
+name: "Digital signatur example forms"
+type: module
+description: "Digital signatur example forms"
+package: ITK Dev example forms
+core_version_requirement: ^10 || ^11
+dependencies:
+  - itkdev_example_forms:itkdev_example_forms
+  - os2forms_digital_signature:os2forms_digital_signature

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.install
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.install
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Install and update functions for the itkdev_ex_digital_signature module.
+ */
+
+use Drupal\itkdev_example_forms\Fixture\UserAffiliationTermFixture;
+use Drupal\itkdev_example_forms\WebformHelper;
+
+/**
+ * Implements hook_install().
+ */
+function itkdev_ex_digital_signature_install(bool $is_syncing): void {
+  /** @var \Drupal\itkdev_example_forms\WebformHelper $helper */
+  $helper = \Drupal::service(WebformHelper::class);
+  $webforms = $helper->loadWebforms('itkdev_ex_digital_signature_');
+  foreach ($webforms as $webform) {
+    $helper->createWebformPage($webform, [
+      'title' => $webform->label(),
+      WebformHelper::FIELD_OS2FORMS_PERMISSIONS => [
+        UserAffiliationTermFixture::ITK_DEVELOPMENT,
+      ],
+    ]);
+  }
+}
+
+/**
+ * Implements hook_uninstall().
+ *
+ * Enforced dependency config removal does not clean up the webform serial
+ * tracking table or the page nodes created in hook_install(). Both must be
+ * deleted explicitly to avoid errors on reinstall.
+ */
+function itkdev_ex_digital_signature_uninstall(bool $is_syncing): void {
+  /** @var \Drupal\itkdev_example_forms\WebformHelper $helper */
+  $helper = \Drupal::service(WebformHelper::class);
+  $webforms = $helper->loadWebforms('itkdev_ex_digital_signature_');
+
+  foreach ($webforms as $webform) {
+    // Delete the webform page node.
+    if ($page = $helper->loadWebformPage($webform->id())) {
+      $page->delete();
+    }
+    // Delete the webform entity (also cleans up the webform serial table).
+    $webform->delete();
+  }
+}

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.services.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.services.yml
@@ -1,0 +1,15 @@
+services:
+  _defaults:
+    autowire: true
+
+  logger.channel.itkdev_ex_digital_signature:
+    parent: logger.channel_base
+    arguments: ["itkdev_ex_digital_signature"]
+
+#  Drupal\itkdev_ex_digital_signature\SettingsHelper:
+#    tags:
+#      - { name: event_subscriber }
+#
+#  Drupal\itkdev_ex_digital_signature\Config\ConfigOverrides:
+#    tags:
+#      - { name: config.factory.override, priority: 5 }

--- a/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.services.yml
+++ b/web/modules/custom/itkdev_example_forms/modules/itkdev_ex_digital_signature/itkdev_ex_digital_signature.services.yml
@@ -5,11 +5,3 @@ services:
   logger.channel.itkdev_ex_digital_signature:
     parent: logger.channel_base
     arguments: ["itkdev_ex_digital_signature"]
-
-#  Drupal\itkdev_ex_digital_signature\SettingsHelper:
-#    tags:
-#      - { name: event_subscriber }
-#
-#  Drupal\itkdev_ex_digital_signature\Config\ConfigOverrides:
-#    tags:
-#      - { name: config.factory.override, priority: 5 }

--- a/web/modules/custom/os2forms_custom_view_builders/os2forms_custom_view_builders.services.yml
+++ b/web/modules/custom/os2forms_custom_view_builders/os2forms_custom_view_builders.services.yml
@@ -1,7 +1,7 @@
 services:
   os2forms_custom_view_builders.digital_signature_link_stripper_subscriber:
     class: Drupal\os2forms_custom_view_builders\EventSubscriber\DigitalSignatureLinkStripperSubscriber
-    arguments: ['@request_stack']
+    arguments: ["@request_stack"]
     tags:
       - { name: event_subscriber }
 
@@ -9,8 +9,8 @@ services:
     class: Drupal\os2forms_custom_view_builders\PrintBuilder\DigitalSignatureFlaggingPrintBuilder
     decorates: os2forms_attachment.print_builder
     arguments:
-      - '@entity_print.renderer_factory'
-      - '@event_dispatcher'
-      - '@string_translation'
-      - '@file_system'
-      - '@request_stack'
+      - "@entity_print.renderer_factory"
+      - "@event_dispatcher"
+      - "@string_translation"
+      - "@file_system"
+      - "@request_stack"

--- a/web/modules/custom/os2forms_custom_view_builders/os2forms_custom_view_builders.services.yml
+++ b/web/modules/custom/os2forms_custom_view_builders/os2forms_custom_view_builders.services.yml
@@ -1,0 +1,16 @@
+services:
+  os2forms_custom_view_builders.digital_signature_link_stripper_subscriber:
+    class: Drupal\os2forms_custom_view_builders\EventSubscriber\DigitalSignatureLinkStripperSubscriber
+    arguments: ['@request_stack']
+    tags:
+      - { name: event_subscriber }
+
+  os2forms_custom_view_builders.digital_signature_flagging_print_builder:
+    class: Drupal\os2forms_custom_view_builders\PrintBuilder\DigitalSignatureFlaggingPrintBuilder
+    decorates: os2forms_attachment.print_builder
+    arguments:
+      - '@entity_print.renderer_factory'
+      - '@event_dispatcher'
+      - '@string_translation'
+      - '@file_system'
+      - '@request_stack'

--- a/web/modules/custom/os2forms_custom_view_builders/src/CustomViewBuilderWebformSubmission.php
+++ b/web/modules/custom/os2forms_custom_view_builders/src/CustomViewBuilderWebformSubmission.php
@@ -2,12 +2,17 @@
 
 namespace Drupal\os2forms_custom_view_builders;
 
+use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
+use Drupal\Core\Render\Element;
+use Drupal\os2forms_custom_view_builders\PrintBuilder\DigitalSignatureFlaggingPrintBuilder;
 use Drupal\webform\Twig\WebformTwigExtension;
 use Drupal\webform\Utility\WebformElementHelper;
 use Drupal\webform\Utility\WebformYaml;
 use Drupal\webform\WebformSubmissionInterface;
 use Drupal\webform\WebformSubmissionViewBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Defines a class override webform submission view builder.
@@ -21,6 +26,20 @@ use Drupal\webform\WebformSubmissionViewBuilder;
  * @see \Drupal\webform\Entity\WebformSubmission
  */
 class CustomViewBuilderWebformSubmission extends WebformSubmissionViewBuilder {
+
+  /**
+   * The request stack.
+   */
+  protected RequestStack $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function createInstance(ContainerInterface $container, EntityTypeInterface $entity_type) {
+    $instance = parent::createInstance($container, $entity_type);
+    $instance->requestStack = $container->get('request_stack');
+    return $instance;
+  }
 
   /**
    * {@inheritdoc}
@@ -90,6 +109,9 @@ class CustomViewBuilderWebformSubmission extends WebformSubmissionViewBuilder {
         case 'table':
           /* @internal OS2Forms changes start */
           $elements = $webform->getElementsInitializedAndFlattened();
+          if ($this->isDigitalSignatureAttachmentRender()) {
+            $this->overrideFormatsForPdf($elements);
+          }
           /* @internal OS2Forms changes end */
           $build[$id]['data'] = $this->buildTable($elements, $webform_submission, $options);
           break;
@@ -97,12 +119,54 @@ class CustomViewBuilderWebformSubmission extends WebformSubmissionViewBuilder {
         default:
         case 'html':
           $elements = $webform->getElementsInitialized();
+          /* @internal OS2Forms changes start */
+          if ($this->isDigitalSignatureAttachmentRender()) {
+            $this->overrideFormatsForPdf($elements);
+          }
+          /* @internal OS2Forms changes end */
           $build[$id]['data'] = $this->buildElements($elements, $webform_submission, $options);
           break;
       }
     }
 
     EntityViewBuilder::buildComponents($build, $entities, $displays, $view_mode);
+  }
+
+  /**
+   * Whether the current request is rendering a digital-signature attachment.
+   */
+  private function isDigitalSignatureAttachmentRender(): bool {
+    $request = $this->requestStack->getCurrentRequest();
+
+    return (bool) $request?->attributes->get(DigitalSignatureFlaggingPrintBuilder::REQUEST_ATTRIBUTE);
+  }
+
+  /**
+   * Override element display formats for PDF rendering (no links).
+   *
+   * When rendering webform submissions as PDF attachments for digital
+   * signature, element values must not be displayed as clickable links.
+   *
+   * @param array $elements
+   *   The webform elements array (nested or flat).
+   */
+  private function overrideFormatsForPdf(array &$elements): void {
+    $formatOverrides = [
+      'managed_file' => 'name',
+      'webform_document_file' => 'name',
+      'webform_audio_file' => 'name',
+      'webform_video_file' => 'name',
+      'webform_image_file' => 'name',
+    ];
+
+    foreach (Element::children($elements) as $key) {
+      $type = $elements[$key]['#type'] ?? '';
+      if (isset($formatOverrides[$type])) {
+        $elements[$key]['#format'] = $formatOverrides[$type];
+      }
+      // Recurse for nested child elements.
+      $this->overrideFormatsForPdf($elements[$key]);
+    }
   }
 
   /**

--- a/web/modules/custom/os2forms_custom_view_builders/src/EventSubscriber/DigitalSignatureLinkStripperSubscriber.php
+++ b/web/modules/custom/os2forms_custom_view_builders/src/EventSubscriber/DigitalSignatureLinkStripperSubscriber.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Drupal\os2forms_custom_view_builders\EventSubscriber;
+
+use Drupal\entity_print\Event\PrintEvents;
+use Drupal\entity_print\Event\PrintHtmlAlterEvent;
+use Drupal\os2forms_custom_view_builders\PrintBuilder\DigitalSignatureFlaggingPrintBuilder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Strips anchor tags from PDFs generated for digital-signature attachments.
+ */
+final readonly class DigitalSignatureLinkStripperSubscriber implements EventSubscriberInterface {
+
+  public function __construct(private RequestStack $requestStack) {
+  }
+
+  /**
+   * Strip <a> tags from the rendered HTML, preserving inner content.
+   */
+  public function onPrintRender(PrintHtmlAlterEvent $event): void {
+    $request = $this->requestStack->getCurrentRequest();
+    if (!$request?->attributes->get(DigitalSignatureFlaggingPrintBuilder::REQUEST_ATTRIBUTE)) {
+      return;
+    }
+    $html = &$event->getHtml();
+    // Strip <a> tags from the rendered HTML, preserving inner content.
+    $html = preg_replace('@<a\b[^>]*>(.*?)</a>@is', '$1', $html);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      PrintEvents::POST_RENDER => ['onPrintRender'],
+    ];
+  }
+
+}

--- a/web/modules/custom/os2forms_custom_view_builders/src/PrintBuilder/DigitalSignatureFlaggingPrintBuilder.php
+++ b/web/modules/custom/os2forms_custom_view_builders/src/PrintBuilder/DigitalSignatureFlaggingPrintBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\os2forms_custom_view_builders\PrintBuilder;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\entity_print\Plugin\PrintEngineInterface;
+use Drupal\entity_print\Renderer\RendererFactoryInterface;
+use Drupal\os2forms_attachment\Os2formsAttachmentPrintBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Decorates the OS2Forms attachment print builder.
+ *
+ * Sets a request attribute while a digital-signature attachment element is
+ * being rendered to PDF, so other code (post-render subscriber, view builder)
+ * can detect that exact context.
+ */
+final class DigitalSignatureFlaggingPrintBuilder extends Os2formsAttachmentPrintBuilder {
+
+  public const REQUEST_ATTRIBUTE = '_os2forms_digital_signature_attachment';
+
+  public function __construct(
+    RendererFactoryInterface $renderer_factory,
+    EventDispatcherInterface $event_dispatcher,
+    TranslationInterface $string_translation,
+    FileSystemInterface $file_system,
+    private readonly RequestStack $requestStack,
+  ) {
+    parent::__construct($renderer_factory, $event_dispatcher, $string_translation, $file_system);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function savePrintableDigitalSignature(array $entities, PrintEngineInterface $print_engine, $scheme = 'public', $filename = FALSE, $use_default_css = TRUE, string $signaturePosition = self::SIGNATURE_POSITION_AFTER_CONTENT) {
+    $request = $this->requestStack->getCurrentRequest();
+    $request?->attributes->set(self::REQUEST_ATTRIBUTE, TRUE);
+    try {
+      return parent::savePrintableDigitalSignature($entities, $print_engine, $scheme, $filename, $use_default_css, $signaturePosition);
+    }
+    finally {
+      $request?->attributes->remove(self::REQUEST_ATTRIBUTE);
+    }
+  }
+
+}

--- a/web/modules/custom/os2forms_custom_view_builders/src/PrintBuilder/DigitalSignatureFlaggingPrintBuilder.php
+++ b/web/modules/custom/os2forms_custom_view_builders/src/PrintBuilder/DigitalSignatureFlaggingPrintBuilder.php
@@ -33,6 +33,13 @@ final class DigitalSignatureFlaggingPrintBuilder extends Os2formsAttachmentPrint
 
   /**
    * {@inheritdoc}
+   *
+   * @param string $scheme
+   *   Stream wrapper scheme to save to.
+   * @param string|false $filename
+   *   Target filename, or FALSE to derive one.
+   * @param bool $use_default_css
+   *   Whether to include the default CSS.
    */
   public function savePrintableDigitalSignature(array $entities, PrintEngineInterface $print_engine, $scheme = 'public', $filename = FALSE, $use_default_css = TRUE, string $signaturePosition = self::SIGNATURE_POSITION_AFTER_CONTENT) {
     $request = $this->requestStack->getCurrentRequest();

--- a/web/modules/custom/os2forms_custom_view_builders/src/PrintBuilder/DigitalSignatureFlaggingPrintBuilder.php
+++ b/web/modules/custom/os2forms_custom_view_builders/src/PrintBuilder/DigitalSignatureFlaggingPrintBuilder.php
@@ -34,12 +34,18 @@ final class DigitalSignatureFlaggingPrintBuilder extends Os2formsAttachmentPrint
   /**
    * {@inheritdoc}
    *
+   * @param array $entities
+   *   The entities to print.
+   * @param \Drupal\entity_print\Plugin\PrintEngineInterface $print_engine
+   *   The print engine.
    * @param string $scheme
    *   Stream wrapper scheme to save to.
    * @param string|false $filename
    *   Target filename, or FALSE to derive one.
    * @param bool $use_default_css
    *   Whether to include the default CSS.
+   * @param string $signaturePosition
+   *   Position for the digital signature validation text.
    */
   public function savePrintableDigitalSignature(array $entities, PrintEngineInterface $print_engine, $scheme = 'public', $filename = FALSE, $use_default_css = TRUE, string $signaturePosition = self::SIGNATURE_POSITION_AFTER_CONTENT) {
     $request = $this->requestStack->getCurrentRequest();


### PR DESCRIPTION
https://leantime.itkdev.dk/_#/tickets/showTicket/7165

* Strips links from the rendered OS2Forms Attachment when it is configured to use Digital Signature.

Does so by

1. Mark when a signature PDF is being generated, see `DigitalSignatureFlaggingPrintBuilder`.
2. Strip `<a>` from the rendered HTML, see `DigitalSignatureLinkStripperSubscriber`.
3. Render file element values as plain filenames, see `CustomViewBuilderWebformSubmission::overrideFormatsForPdf()`.
