### PR TITLE
mTLS config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* [PR-500](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/500)
+  Added mTLS config
 * [PR-494](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/494)
   Undlod at eksportere eksempelformularkonfiguration
 * [PR-489](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/489)

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -40,3 +40,17 @@ services:
   nginx:
     environment:
       - NGINX_MAX_BODY_SIZE=305M
+    labels:
+      # mTLS is needed for callbacks from Fordelingskomponenten
+      #
+      # We can only enable mTLS on (sub)domains; not on a path (contrary to what
+      # is claimed on
+      # https://community.traefik.io/t/configure-clientauth-mtls-for-docker-container/26935)
+      #
+      # Note: Using two subdomains, e.g. mtls.selvbetjening.aarhuskommune.dk
+      # will not work with Aarhus kommunes wildcard certificate. Therefore we
+      # prefix the existing subdomain with `mtls-`.
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-mtls.rule=Host(`mtls-${COMPOSE_SERVER_DOMAIN:?}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-mtls.entrypoints=websecure"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-mtls.tls.options=mtls@file"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-mtls.middlewares=mtls-passtlsclientcert@file"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,9 @@ services:
       # Cron-metrics protection.
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.rule=Host(`${COMPOSE_DOMAIN:?}`) && PathPrefix(`/cron-metrics`) "
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-metrics.middlewares=ITKMetricsAuth@file"
+      # mTLS (doesn't yet make much sense for development)
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-mtls.rule=Host(`mtls-${COMPOSE_DOMAIN:?}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME:?}-mtls.middlewares=redirect-to-https"
 
   memcached:
     image: memcached:alpine


### PR DESCRIPTION
Adds Traefik labels to enable mTLS on the domain used for calbacks from Fordelingskomponenten.
