### PR TITLE
Config ignored digital signature settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* [PR-501](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/501)
+  Tilføjede Digital signatur indstillinger til config-ignore.
 * [PR-486](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/486)
   Style progress bar ud fra "Det fælles design system".
 * [PR-497](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/497)

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -16,6 +16,7 @@ ignored_config_entities:
   - "maestro.maestro_template.*"
   - "os2forms_attachment.os2forms_attachment_component.*"
   - os2forms_digital_post.settings
+  - os2forms_digital_signature.settings
   - os2forms_encrypt.settings
   - os2forms_fasit.settings
   - os2forms_forloeb.settings


### PR DESCRIPTION
https://leantime.itkdev.dk/_#/tickets/showTicket/7487

Ensures Digital signature settings aren't removed during config:import

* Adds Digital signature settings to config ignore.