### PR TITLE
Added warning on missing webform settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* [PR-520](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/520)
+  Tilføjede advarsel om manglede formularindstillinger.
+
 ## [5.1.10] 2026-06-22
 
 * [PR-517](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/517)

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
@@ -5,6 +5,7 @@
  * Module file for the os2forms_selvbetjening module.
  */
 
+use Drupal\os2forms_selvbetjening\Hooks\WebformValidationHooks;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\os2forms_selvbetjening\Helper\FormHelper;
 
@@ -22,6 +23,9 @@ function os2forms_selvbetjening_form_alter(array &$form, FormStateInterface $for
       $form['spv']['method']['#options']['bycontentfunction'] .= t('. Read more: <a href="https://os2forms.os2.eu/variabler-i-flow" target="_blank">https://os2forms.os2.eu/variabler-i-flow</a>');
     }
   }
+
+  // @todo Remove this file when upgrading to Drupal 11 (cf. https://www.drupal.org/node/3442349).
+  Drupal::service(WebformValidationHooks::class)->formAlter($form, $form_state, $form_id);
 }
 
 /**

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.services.yml
@@ -1,4 +1,7 @@
 services:
+  _defaults:
+    autowire: true
+
   logger.channel.os2forms_selvbetjening:
     parent: logger.channel_base
     arguments: ["os2forms_selvbetjening"]
@@ -36,3 +39,5 @@ services:
         "@plugin.manager.advancedqueue_job_type",
         "@logger.channel.cron",
       ]
+
+  Drupal\os2forms_selvbetjening\Hooks\WebformValidationHooks:

--- a/web/modules/custom/os2forms_selvbetjening/src/Hooks/WebformValidationHooks.php
+++ b/web/modules/custom/os2forms_selvbetjening/src/Hooks/WebformValidationHooks.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Drupal\os2forms_selvbetjening\Hooks;
+
+use Drupal\Core\Entity\EntityFormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Routing\AdminContext;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+use Drupal\webform\Plugin\WebformHandlerInterface;
+use Drupal\webform\WebformInterface;
+
+/**
+ * Webform validation.
+ */
+class WebformValidationHooks {
+  use StringTranslationTrait;
+
+  private const array FILE_ELEMENT_TYPES = [
+    'managed_file', 'webform_image_file',
+    'webform_audio_file', 'webform_video_file', 'webform_document_file',
+  ];
+
+  private const array EMAIL_HANDLER_PLUGIN_IDS = [
+    'email',
+  ];
+
+  /**
+   * IDs of form on which we want to show warnings.
+   *
+   * Note: For some reason messenger messages does not show up on all pages,
+   * e.g. on the webform's general settings form (webform_settings_form), but we
+   * include that ID for completeness.
+   */
+  private const array WEBFORM_FORM_IDS = [
+    'webform_edit_form',
+    'webform_handlers_form',
+    'webform_settings_form',
+  ];
+
+  public function __construct(
+    private readonly RouteMatchInterface $routeMatch,
+    private readonly AdminContext $adminContext,
+    private readonly MessengerInterface $messenger,
+  ) {
+  }
+
+  /**
+   * Implements hook_form_alter().
+   *
+   * @todo Add #[Hook('form_alter')] when upgrading to
+   * Drupal 11 (cf. https://www.drupal.org/node/3442349).
+   */
+  public function formAlter(array &$form, FormStateInterface $form_state, string $form_id) {
+    $route = $this->routeMatch->getRouteObject();
+    if (!$this->adminContext->isAdminRoute($route)) {
+      return;
+    }
+
+    if (in_array($form_id, self::WEBFORM_FORM_IDS, TRUE)) {
+      $formObject = $form_state->getFormObject();
+      if ($formObject instanceof EntityFormInterface) {
+        $entity = $formObject->getEntity();
+        if ($entity instanceof WebformInterface) {
+          $this->showWebformWarnings($entity);
+        }
+      }
+    }
+  }
+
+  /**
+   * Show warnings on webform settings – or lack of settings ...
+   */
+  private function showWebformWarnings(WebformInterface $webform): void {
+    if ($this->hasFileElement($webform) && $this->hasEmailHandler($webform)) {
+      $settings = $webform->getThirdPartySettings('os2forms')['os2forms_email_handler'] ?? NULL;
+      $enabled = $settings['enabled'] ?? FALSE;
+      $recipients = trim((string) ($settings['email_recipients'] ?? NULL));
+      if (!$enabled || '' === $recipients) {
+        $this->messenger->addWarning(
+          $this->t('This webform has an attachment element and an email handler, but notifications on large attachments are not enabled. Go to <a href=":settings_url">@settings » @general » @third_party_settings » OS2Forms » @os2forms_email_handler</a> and activate them.', [
+            ':settings_url' => Url::fromRoute('entity.webform.settings', [
+              'webform' => $webform->id(),
+            ],
+            [
+              'fragment' => 'edit-third-party-settings-os2forms-os2forms-email-handler',
+            ],
+            )->toString(TRUE)->getGeneratedUrl(),
+            '@settings' => $this->t('Settings'),
+            '@general' => $this->t('General'),
+            '@third_party_settings' => $this->t('Third party settings'),
+            '@os2forms_email_handler' => $this->t('OS2Forms email handler'),
+          ]));
+      }
+    }
+  }
+
+  /**
+   * Get all file elements on a webform.
+   */
+  private function getFileElements(WebformInterface $webform): array {
+    return array_filter(
+      $webform->getElementsDecodedAndFlattened(),
+      static fn (array $element): bool => in_array($element['#type'] ?? NULL, self::FILE_ELEMENT_TYPES, TRUE)
+    );
+  }
+
+  /**
+   * Decide if a webform has a file element.
+   */
+  private function hasFileElement(WebformInterface $webform): bool {
+    return !empty($this->getFileElements($webform));
+  }
+
+  /**
+   * Get email handlers on a webform.
+   */
+  private function getEmailHandlers(WebformInterface $webform): array {
+    return array_filter(
+      iterator_to_array($webform->getHandlers()->getIterator()),
+      static fn(WebformHandlerInterface $handler): bool => in_array($handler->getPluginId(), self::EMAIL_HANDLER_PLUGIN_IDS, TRUE)
+    );
+  }
+
+  /**
+   * Decide if a webform has an email handler.
+   */
+  private function hasEmailHandler(WebformInterface $webform): bool {
+    return !empty($this->getEmailHandlers($webform));
+  }
+
+}


### PR DESCRIPTION
Inspired by support issue https://leantime.itkdev.dk/_#/tickets/showTicket/7804.

Show warning on missing webform settings issues on select forms:

<img width="1602" height="255" alt="Screenshot 2026-06-19 at 12 41 20" src="https://github.com/user-attachments/assets/6072e987-47f5-4291-b62e-af5a455e4273" />

