### PR TITLE
Updated itk-dev/os2forms_nemlogin_openid_connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+## [5.1.12] 2026-07-14
+
+* [PR-526](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/526)
+   Opdaterede til `itk-dev/os2forms_nemlogin_openid_connect` `2.5.0`
+    * Der benyttes nu sessionstype specifikke sessionsnøgler.
+
 ## [5.1.11] 2026-07-02
 
 * [PR-520](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/520)
@@ -847,7 +853,8 @@ og [OS2Forms 3.7.0](https://github.com/OS2Forms/os2forms/releases/tag/3.7.0)
 
 * GO borgersager
 
-[Under udvikling]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.11...HEAD
+[Under udvikling]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.12...HEAD
+[5.1.12]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.11...5.1.12
 [5.1.11]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.10...5.1.11
 [5.1.10]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.9...5.1.10
 [5.1.9]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.8...5.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 ## [5.1.12] 2026-07-14
 
 * [PR-526](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/526)
-   Opdaterede til `itk-dev/os2forms_nemlogin_openid_connect` `2.5.0`
-    * Der benyttes nu sessionstype specifikke sessionsnøgler.
+   Opdaterede til `itk-dev/os2forms_nemlogin_openid_connect` `2.5.1`
+  * Der benyttes nu sessionstype specifikke sessionsnøgler.
 
 ## [5.1.11] 2026-07-02
 

--- a/composer.lock
+++ b/composer.lock
@@ -8243,22 +8243,22 @@
         },
         {
             "name": "itk-dev/os2forms_nemlogin_openid_connect",
-            "version": "2.3.1",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect.git",
-                "reference": "c7f403ce68b3d3fe112afa476beeb36f0100342e"
+                "reference": "10dc73262f081ae770f3457acbd2d931c912200e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/itk-dev/os2forms_nemlogin_openid_connect/zipball/c7f403ce68b3d3fe112afa476beeb36f0100342e",
-                "reference": "c7f403ce68b3d3fe112afa476beeb36f0100342e",
+                "url": "https://api.github.com/repos/itk-dev/os2forms_nemlogin_openid_connect/zipball/10dc73262f081ae770f3457acbd2d931c912200e",
+                "reference": "10dc73262f081ae770f3457acbd2d931c912200e",
                 "shasum": ""
             },
             "require": {
                 "drupal/webform": "^6.0",
                 "itk-dev/drupal_psr6_cache": "^1.1",
-                "itk-dev/openid-connect": "^3.1",
+                "itk-dev/openid-connect": "^3.1 || ^4.0",
                 "os2web/os2web_audit": "^1.0",
                 "os2web/os2web_key": "^1.0",
                 "os2web/os2web_nemlogin": "^1.2",
@@ -8289,9 +8289,9 @@
             "homepage": "https://www.drupal.org/project/os2forms_nemlogin_openid_connect",
             "support": {
                 "issues": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect/issues",
-                "source": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect/tree/2.3.1"
+                "source": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect/tree/2.5.0"
             },
-            "time": "2025-12-12T12:38:46+00:00"
+            "time": "2026-07-14T11:17:29+00:00"
         },
         {
             "name": "itk-dev/os2forms_user_field_lookup",

--- a/composer.lock
+++ b/composer.lock
@@ -8243,16 +8243,16 @@
         },
         {
             "name": "itk-dev/os2forms_nemlogin_openid_connect",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect.git",
-                "reference": "10dc73262f081ae770f3457acbd2d931c912200e"
+                "reference": "80c5f857063c34fb723ec1172fb39edb70a237cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/itk-dev/os2forms_nemlogin_openid_connect/zipball/10dc73262f081ae770f3457acbd2d931c912200e",
-                "reference": "10dc73262f081ae770f3457acbd2d931c912200e",
+                "url": "https://api.github.com/repos/itk-dev/os2forms_nemlogin_openid_connect/zipball/80c5f857063c34fb723ec1172fb39edb70a237cf",
+                "reference": "80c5f857063c34fb723ec1172fb39edb70a237cf",
                 "shasum": ""
             },
             "require": {
@@ -8289,9 +8289,9 @@
             "homepage": "https://www.drupal.org/project/os2forms_nemlogin_openid_connect",
             "support": {
                 "issues": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect/issues",
-                "source": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect/tree/2.5.0"
+                "source": "https://github.com/itk-dev/os2forms_nemlogin_openid_connect/tree/2.5.1"
             },
-            "time": "2026-07-14T11:17:29+00:00"
+            "time": "2026-07-16T07:57:50+00:00"
         },
         {
             "name": "itk-dev/os2forms_user_field_lookup",


### PR DESCRIPTION
Updates to `itk-dev/os2forms_nemlogin_openid_connect` [`2.5.1`](https://github.com/itk-dev/os2forms_nemlogin_openid_connect/releases/tag/2.5.1)

* Generate and use unique token keys across OIDC providers