### PR TITLE
Avoid hidden overflow in chosen select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+* [PR-528](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/528)
+  Sikrede at drop-down menuer på administrationssider ikke blive cuttet af.
 * [PR-527](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/527)
   Rettede placeringen af tidsfeltet i `datetime`-elementet når der benyttes
   `timepicker`.

--- a/web/modules/custom/os2forms_selvbetjening/css/chosen-gin-overflow.css
+++ b/web/modules/custom/os2forms_selvbetjening/css/chosen-gin-overflow.css
@@ -1,0 +1,13 @@
+/**
+ * Un-clip open Chosen dropdowns inside Gin's table scroll wrapper.
+ *
+ * Gin wraps admin tables in .gin-table-scroll-wrapper (overflow-x: auto,
+ * overflow-y: hidden), which clips the absolutely positioned .chosen-drop.
+ * Only relax the clipping while a dropdown is open (.chosen-with-drop), so
+ * wide tables keep their horizontal scroll the rest of the time.
+ *
+ * @see https://www.drupal.org/project/gin/issues/3501828
+ */
+.gin-table-scroll-wrapper:has(.chosen-container.chosen-with-drop) {
+  overflow: visible;
+}

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.libraries.yml
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.libraries.yml
@@ -7,6 +7,11 @@ author_bulk_assignment:
   css:
     theme:
       assets/css/author_bulk_assignment.css: {}
+chosen-gin-overflow:
+  version: 1.x
+  css:
+    theme:
+      css/chosen-gin-overflow.css: {}
 dawa_address_autocomplete:
   version: 1.x
   js:

--- a/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
+++ b/web/modules/custom/os2forms_selvbetjening/os2forms_selvbetjening.module
@@ -44,6 +44,19 @@ function os2forms_selvbetjening_webform_element_alter(array &$element, FormState
 }
 
 /**
+ * Implements hook_library_info_alter().
+ *
+ * Gin's table scroll wrapper clips open Chosen dropdowns
+ * (cf. https://www.drupal.org/project/gin/issues/3501828). Load our fix
+ * whenever Gin's Chosen styling loads.
+ */
+function os2forms_selvbetjening_library_info_alter(array &$libraries, string $extension) {
+  if ('gin' === $extension && isset($libraries['chosen'])) {
+    $libraries['chosen']['dependencies'][] = 'os2forms_selvbetjening/chosen-gin-overflow';
+  }
+}
+
+/**
  * Implements hook_views_plugins_field_alter().
  */
 function os2forms_selvbetjening_views_plugins_field_alter(array &$plugins) {


### PR DESCRIPTION
* Avoid hidden overflow when chosen takes over selects

Before:

<img width="820" height="782" alt="Screenshot 2026-07-20 at 14 21 09" src="https://github.com/user-attachments/assets/93b9e309-7271-430a-bdd1-1a88bdac9422" />


After:

<img width="830" height="795" alt="Screenshot 2026-07-20 at 14 20 28" src="https://github.com/user-attachments/assets/c4f5d9f1-06a2-460d-ae4e-9f1ff4b41356" />
