### PR TITLE
8052: Read the Nemlogin user token from the session key introduced in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
 
 ## [Under udvikling]
 
+## [5.1.15] 2026-07-28
+
+* [PR-532](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/532)
+  Rettede manglende brugerdata i booking-indsendelser efter opdateringen til
+  `itk-dev/os2forms_nemlogin_openid_connect` `2.5.x`, hvor brugertokenet gemmes
+  under sessionstype-specifikke sessionsnøgler.
+
 ## [5.1.14] 2026-07-27
 
 * [PR-530](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/530)
@@ -868,7 +875,8 @@ og [OS2Forms 3.7.0](https://github.com/OS2Forms/os2forms/releases/tag/3.7.0)
 
 * GO borgersager
 
-[Under udvikling]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.14...HEAD
+[Under udvikling]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.15...HEAD
+[5.1.15]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.14...5.1.15
 [5.1.14]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.13...5.1.14
 [5.1.13]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.12...5.1.13
 [5.1.12]: https://github.com/itk-dev/os2forms_selvbetjening/compare/5.1.11...5.1.12

--- a/web/modules/custom/itkdev_booking/src/Helper/UserHelper.php
+++ b/web/modules/custom/itkdev_booking/src/Helper/UserHelper.php
@@ -10,6 +10,11 @@ use Symfony\Component\HttpFoundation\Request;
  *
  */
 class UserHelper {
+  /**
+   * Id of the auth provider plugin used for logging in on booking webforms.
+   */
+  private const AUTH_PROVIDER_PLUGIN_ID = 'openid_connect_nemlogin';
+
   protected bool $bookingApiSampleUser;
 
   public function __construct() {
@@ -63,7 +68,7 @@ class UserHelper {
     }
 
     $session = $request->getSession();
-    $userToken = $session->get('os2forms_nemlogin_openid_connect.user_token');
+    $userToken = $session->get('os2forms_nemlogin_openid_connect.user_token_' . self::AUTH_PROVIDER_PLUGIN_ID);
 
     if (isset($userToken['cvr'])) {
       $permission = 'businessPartner';


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/8052

* Correctly use session key introduced by `os2forms_nemlogin_openid_connect` `2.5`, cf. https://github.com/itk-dev/os2forms_nemlogin_openid_connect/pull/28/changes

> [!NOTE]
> Note that this assumes that the nemlogin session has the id "openid_connect_nemlogin". But this is a POC that has entered prodcution. Ideally we would reject users access to the webform if the needed user data could not be fetched.