### PR TITLE
8052: Added validation of session user data on booking submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Nedenfor ses dato for release og beskrivelse af opgaver som er implementeret.
   Rettede manglende brugerdata i booking-indsendelser efter opdateringen til
   `itk-dev/os2forms_nemlogin_openid_connect` `2.5.x`, hvor brugertokenet gemmes
   under sessionstype-specifikke sessionsnøgler.
+* [533](https://github.com/itk-dev/selvbetjening.aarhuskommune.dk/pull/533)
+  Tilføjede validering der afviser bookingindsendelser med en fejlbesked,
+  hvis brugerens sessionsdata mangler.
 
 ## [5.1.14] 2026-07-27
 

--- a/web/modules/custom/itkdev_booking/src/Plugin/WebformElement/BookingElement.php
+++ b/web/modules/custom/itkdev_booking/src/Plugin/WebformElement/BookingElement.php
@@ -229,6 +229,16 @@ class BookingElement extends Hidden {
     $elements = $form['elements'];
     foreach ($elements as $key => $form_element) {
       if (is_array($form_element) && isset($form_element['#type']) && 'booking_element' === $form_element['#type']) {
+        // Abandon the submission if the user data that preSave() attaches is
+        // missing; Book Aarhus rejects bookings without it.
+        $userHelper = new UserHelper();
+        $userArray = $userHelper->getUserValues(\Drupal::request());
+
+        if (empty($userArray['name']) || empty($userArray['userId'])) {
+          $form_state->setError($form, t('Required session values are missing. Please try again. If the error persists, contact the person responsible for this form.'));
+          return;
+        }
+
         try {
           $bookingValues = json_decode($form_state->getValues()[$key], TRUE, 512, JSON_THROW_ON_ERROR);
         }


### PR DESCRIPTION
https://leantime.itkdev.dk/#/tickets/showTicket/8052

* Validates the required user session data is available when submitting.

Displays and error if it missing saying:

_Required session values are missing. Please try again. If the error persists, contact the person responsible for this form._

> [!IMPORTANT]
> Needs rebasing and thorough testing before moving on with this feature. 
